### PR TITLE
Makefile: Add extra flag CORE_DEBUG_LEVEL

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,8 @@ SRCS := $(shell find $(SRCDIR) -name "*.ino" -or -name "*.cpp" -or -name "*.c" -
 # Compute version string from git sandbox status
 VERSION_STRING := $(shell git describe --always --tags --dirty)
 
+CPP_EXTRA_FLAGS := -DCORE_DEBUG_LEVEL=5
+
 ifdef API_SECRET_SALT
 CPP_EXTRA_FLAGS := -DAPI_SECRET_SALT="$(API_SECRET_SALT)"
 endif


### PR DESCRIPTION
Testing now with level 5 (Verbose). For building the release, it will use LEVEL 1 (Error)