### PR TITLE
Makefile: release: set flag CUSTOM_DEBUG_LEVEL to arduino-cli

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Arduino CLI environment
         run: make env
       - name: Build the sketch
-        run: make API_SECRET_SALT="${{ secrets.API_SECRET_SALT }}" API_SERVER="${{ secrets.API_SERVER }}"
+        run: make API_SECRET_SALT="${{ secrets.API_SECRET_SALT }}" API_SERVER="${{ secrets.API_SERVER }}" CUSTOM_DEBUG_LEVEL=1
       - name: Download external flashing tools to attach to release
         run: curl -o esptool-2.6.1-windows.zip https://dl.espressif.com/dl/esptool-2.6.1-windows.zip && unzip esptool-2.6.1-windows.zip
       - name: Grab core version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Arduino CLI environment
         run: make env
       - name: Build the sketch
-        run: make API_SECRET_SALT="${{ secrets.API_SECRET_SALT }}" API_SERVER="${{ secrets.API_SERVER }}" CUSTOM_DEBUG_LEVEL=1
+        run: make API_SECRET_SALT="${{ secrets.API_SECRET_SALT }}" API_SERVER="${{ secrets.API_SERVER }}" CUSTOM_DEBUG_LEVEL="1"
       - name: Download external flashing tools to attach to release
         run: curl -o esptool-2.6.1-windows.zip https://dl.espressif.com/dl/esptool-2.6.1-windows.zip && unzip esptool-2.6.1-windows.zip
       - name: Grab core version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Arduino CLI environment
         run: make env
       - name: Build the sketch
-        run: make API_SECRET_SALT="${{ secrets.API_SECRET_SALT }}" API_SERVER="${{ secrets.API_SERVER }}" CUSTOM_DEBUG_LEVEL="1"
+        run: make API_SECRET_SALT="${{ secrets.API_SECRET_SALT }}" API_SERVER="${{ secrets.API_SERVER }}" CUSTOM_DEBUG_LEVEL=1
       - name: Download external flashing tools to attach to release
         run: curl -o esptool-2.6.1-windows.zip https://dl.espressif.com/dl/esptool-2.6.1-windows.zip && unzip esptool-2.6.1-windows.zip
       - name: Grab core version

--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ CPP_EXTRA_FLAGS += -DAPI_SERVER="$(API_SERVER)"
 endif
 
 ifndef CUSTOM_DEBUG_LEVEL
-define CUSTOM_DEBUG_LEVEL=5
+CUSTOM_DEBUG_LEVEL := 5
 endif
 
 # Set the location of the Arduino environment.

--- a/Makefile
+++ b/Makefile
@@ -154,7 +154,11 @@ $(BUILDDIR)/$(SKETCH).ino.elf: $(SRCS)
 	--build-path $(BUILDDIR) --build-cache-path $(CACHEDIR) \
 	--build-property $(BUILDPROP) \
 	--build-property 'compiler.cpp.extra_flags=-DVERSION_STRING="$(VERSION_STRING)" $(CPP_EXTRA_FLAGS)' \
+ifdef CUSTOM_DEBUG_LEVEL
+	--build-property 'build.code_debug=CUSTOM_DEBUG_LEVEL' \
+else
 	--build-property 'build.code_debug=1' \
+endif
 	--warnings all --log-file $(LOGDIR)/build.log --log-level debug $(ARGS_VERBOSE) \
 	--fqbn $(FQBN) $(SRCDIR)
 

--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ CPP_EXTRA_FLAGS += -DAPI_SERVER="$(API_SERVER)"
 endif
 
 ifndef CUSTOM_DEBUG_LEVEL
-CUSTOM_DEBUG_LEVEL := "5"
+CUSTOM_DEBUG_LEVEL := 5
 endif
 
 # Set the location of the Arduino environment.
@@ -158,7 +158,7 @@ $(BUILDDIR)/$(SKETCH).ino.elf: $(SRCS)
 	--build-path $(BUILDDIR) --build-cache-path $(CACHEDIR) \
 	--build-property $(BUILDPROP) \
 	--build-property 'compiler.cpp.extra_flags=-DVERSION_STRING="$(VERSION_STRING)" $(CPP_EXTRA_FLAGS)' \
-	--build-property 'build.code_debug=CUSTOM_DEBUG_LEVEL' \
+	--build-property 'build.code_debug=$(CUSTOM_DEBUG_LEVEL)' \
 	--warnings all --log-file $(LOGDIR)/build.log --log-level debug $(ARGS_VERBOSE) \
 	--fqbn $(FQBN) $(SRCDIR)
 

--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ CPP_EXTRA_FLAGS += -DAPI_SERVER="$(API_SERVER)"
 endif
 
 ifndef CUSTOM_DEBUG_LEVEL
-CUSTOM_DEBUG_LEVEL := 5
+CUSTOM_DEBUG_LEVEL := "5"
 endif
 
 # Set the location of the Arduino environment.

--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,10 @@ ifdef API_SERVER
 CPP_EXTRA_FLAGS += -DAPI_SERVER="$(API_SERVER)"
 endif
 
+ifndef CUSTOM_DEBUG_LEVEL
+define CUSTOM_DEBUG_LEVEL=5
+endif
+
 # Set the location of the Arduino environment.
 export ARDUINO_DATA_DIR = $(VARDIR)
 
@@ -154,9 +158,7 @@ $(BUILDDIR)/$(SKETCH).ino.elf: $(SRCS)
 	--build-path $(BUILDDIR) --build-cache-path $(CACHEDIR) \
 	--build-property $(BUILDPROP) \
 	--build-property 'compiler.cpp.extra_flags=-DVERSION_STRING="$(VERSION_STRING)" $(CPP_EXTRA_FLAGS)' \
-ifdef CUSTOM_DEBUG_LEVEL
 	--build-property 'build.code_debug=CUSTOM_DEBUG_LEVEL' \
-endif
 	--warnings all --log-file $(LOGDIR)/build.log --log-level debug $(ARGS_VERBOSE) \
 	--fqbn $(FQBN) $(SRCDIR)
 

--- a/Makefile
+++ b/Makefile
@@ -156,8 +156,6 @@ $(BUILDDIR)/$(SKETCH).ino.elf: $(SRCS)
 	--build-property 'compiler.cpp.extra_flags=-DVERSION_STRING="$(VERSION_STRING)" $(CPP_EXTRA_FLAGS)' \
 ifdef CUSTOM_DEBUG_LEVEL
 	--build-property 'build.code_debug=CUSTOM_DEBUG_LEVEL' \
-else
-	--build-property 'build.code_debug=1' \
 endif
 	--warnings all --log-file $(LOGDIR)/build.log --log-level debug $(ARGS_VERBOSE) \
 	--fqbn $(FQBN) $(SRCDIR)


### PR DESCRIPTION
Ideally this works and allows one to define a custom core debug level through make, including the automated release script (for release level should be 1, so I hardcoded that value in release.yml). Default value if no custom is specified will be 5 (maximum verbosity). All commits will be squashed, sorry for the mess, I'm new to makefile syntax.