### PR TITLE
Release v4.1.6 — bugfix branch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -154,7 +154,7 @@ print-core-version:
 	@echo $$($(BINDIR)/arduino-cli --config-file $(ETCDIR)/arduino-cli.yaml core list | grep "$(CORE_NAME)" | cut -f2 -d' ') ; \
 
 env: $(BINDIR)/arduino-cli $(BINDIR)/arduino-lint $(ETCDIR)/arduino-cli.yaml
-	mkdir -p $(BUILDDIR)
+	mkdir -p $(BUILDDIR) $(LOGDIR)
 	$(BINDIR)/arduino-cli --config-file $(ETCDIR)/arduino-cli.yaml core update-index
 	$(BINDIR)/arduino-cli --config-file $(ETCDIR)/arduino-cli.yaml core install $(CORE)
 ifdef LIBRARIES

--- a/config.h
+++ b/config.h
@@ -151,7 +151,7 @@
 // ===== Version Information =====
 
 #ifndef VERSION_STRING
-#define VERSION_STRING "4.1.4"
+#define VERSION_STRING "4.1.6"
 #endif
 
 #endif // CONFIG_H

--- a/config_generator/.gitignore
+++ b/config_generator/.gitignore
@@ -1,0 +1,24 @@
+# Python virtual environment
+venv/
+env/
+ENV/
+
+# Python cache
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+
+# Generated config files (optional - rimuovi se vuoi tracciare i config generati)
+*.json
+
+# IDE
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# OS
+.DS_Store
+Thumbs.db

--- a/config_generator/CHANGELOG.md
+++ b/config_generator/CHANGELOG.md
@@ -1,0 +1,246 @@
+# Changelog - MSP Config Generator
+
+Tutte le modifiche notevoli a questo progetto saranno documentate in questo file.
+
+---
+
+## [2.2.0] - 2026-01-12
+
+### 🎉 Sistema di Flash Completo con Bootloader
+
+### ✨ Nuove Funzionalità
+
+#### Flash Pacchetto Completo
+- **Download ZIP Completo**: Scarica pacchetto con bootloader + partitions + boot_app0 + firmware
+- **Flash Tutti i Componenti**: Flash di 4 file agli indirizzi corretti (0x1000, 0x8000, 0xe000, 0x10000)
+- **Selezione Automatica 4MB/8MB**: Seleziona il ZIP appropriato in base alla flash size rilevata
+- **Supporto ZIP Locale**: Possibilità di caricare un file ZIP locale con tutti i componenti
+- **Flash Size Detection**: Rileva e salva automaticamente la flash size del dispositivo
+
+#### Nuove Funzioni
+- **`download_firmware_package()`**: Scarica ed estrae il pacchetto firmware completo da GitHub
+- **`flash_firmware_package()`**: Flasha bootloader + partitions + boot_app0 + firmware in una operazione
+- **`get_chip_info_verbose()`**: Rilevamento chip robusto con output di debug
+
+### 🔧 Miglioramenti
+
+- **Rilevamento ESP32 Migliorato**: Rilevamento più robusto con fallback automatici
+- **Warning File .bin Singoli**: Avvisi quando si usa un .bin senza bootloader
+- **Progress Dettagliato**: Feedback per ogni componente durante il flash
+- **Gestione Errori**: Verifica esistenza file prima del flash
+- **Log Dettagliati**: Output di debug per troubleshooting
+
+### 🐛 Bug Fix
+
+- ✅ **CRITICO**: Risolto problema di "brick" dopo erase_flash
+  - Prima: Flash solo firmware → dispositivo non bootava
+  - Ora: Flash bootloader + firmware → dispositivo boota correttamente
+- ✅ Rilevamento chip ora sempre funzionante (anche se parziale)
+- ✅ Flash size sempre rilevata (con stima intelligente se necessario)
+
+### 📝 Documentazione
+
+- **COMPLETE_FLASH_SYSTEM.md**: Documentazione completa del sistema di flash
+- **ESP32_DETECTION_IMPROVED.md**: Guida al rilevamento ESP32 migliorato
+- **README.md**: Aggiornato con nuove funzionalità
+
+### ⚠️ Deprecazioni
+
+- `download_firmware_asset()`: Deprecato, usa `download_firmware_package()`
+- `flash_firmware()`: Deprecato per flash completo, usa `flash_firmware_package()`
+
+---
+
+## [2.1.0] - 2026-01-12
+
+### 🎉 Password Toggle Feature
+
+### ✨ Nuove Funzionalità
+
+#### Password Visibility Toggle
+- **Pulsante Toggle Password (👁️/🔒)**: Nuovo pulsante accanto al campo password
+- **Mostra/Nascondi Password**: Click per visualizzare la password WiFi in chiaro
+- **Feedback Visivo**: Icona cambia da 👁️ (mostra) a 🔒 (nascondi)
+- **Verifica Errori**: Aiuta l'utente a verificare che la password sia corretta
+
+#### Interfaccia Utente Migliorata
+- **Layout a 4 Colonne**: Espanso da 3 a 4 colonne (Label | Entry | Eye | Help)
+- **Nuovo Metodo**: `create_password_entry()` per campi password con toggle
+- **User Experience**: Migliorata l'esperienza utente per l'inserimento password
+
+### 🔧 Miglioramenti
+
+- **Security by Default**: Password sempre nascosta all'avvio
+- **Controllo Utente**: L'utente decide quando mostrare/nascondere
+- **Icone Intuitive**: Uso di emoji universalmente riconoscibili
+
+### 📝 Documentazione
+
+- **FEATURE_PASSWORD_TOGGLE.md**: Documentazione completa della feature
+- **README.md**: Aggiornato con descrizione password toggle
+- **CHANGELOG.md**: Aggiunto entry per v2.1.0
+
+### 🐛 Bug Fix
+
+- Nessun bug noto in questa versione
+
+---
+
+## [2.0.0] - 2026-01-12
+
+### 🎉 Versione Completa con ESP32 Flash
+
+### ✨ Nuove Funzionalità
+
+#### ESP32 Flash Integration
+- **Rilevamento automatico porte COM** cross-platform
+- **Rilevamento automatico flash size** ESP32
+- **Download firmware da GitHub** automatico dall'ultima release
+- **Flash firmware** con barra progresso in tempo reale
+- **Erase flash** completa per troubleshooting
+- **Log dettagliato** di tutte le operazioni
+
+#### Architettura Modulare
+- **config_data.py**: Configurazione centralizzata (valori, help, costanti)
+- **esp32_utils.py**: Utility per ESP32 (porte, flash, chip info)
+- **github_utils.py**: Utility per GitHub (download releases)
+- **config_generator_gui.py**: GUI principale con tabs
+
+#### Interfaccia Utente
+- **Tab Configuration**: Generazione config JSON
+- **Tab ESP32 Flash**: Gestione flash ESP32
+- **Scrolling**: Supporto per schermi piccoli
+- **Help contestuale**: Pulsante ? per ogni campo
+
+#### Script e Automation
+- **run_gui.sh**: Auto-setup per macOS/Linux
+- **run_gui.bat**: Auto-setup per Windows
+- **test_modules.py**: Suite di test completa
+
+#### Documentazione
+- **README.md**: Documentazione completa (280 righe)
+- **QUICK_START.md**: Guida rapida all'uso
+- **CUSTOMIZATION_EXAMPLES.md**: 10 esempi di personalizzazione
+- **CHANGELOG.md**: Questo file
+
+### 🔧 Miglioramenti
+
+- **Validazione avanzata** di tutti i campi
+- **Gestione errori** robusta
+- **Threading** per operazioni lunghe (non blocca la GUI)
+- **Cross-platform** completamente funzionante
+- **Zero dipendenze esterne** (escluso tkinter built-in)
+
+### 🐛 Bug Fix
+
+- Nessun bug noto in questa versione
+
+### 📦 Dipendenze
+
+```
+pyserial>=3.5          # Comunicazione seriale
+esptool>=4.7           # Flash ESP32
+requests>=2.31.0       # Download da GitHub
+```
+
+### 🧪 Testing
+
+- ✅ Testato su macOS (arm64)
+- ✅ Testato download GitHub
+- ✅ Testato rilevamento porte COM
+- ✅ Testato flash ESP32
+- ⏳ Da testare su Linux
+- ⏳ Da testare su Windows
+
+---
+
+## [1.0.0] - 2026-01-12
+
+### 🎉 Versione Iniziale
+
+### ✨ Funzionalità
+
+- Generazione file config_v4.json
+- Interfaccia grafica con tutti i parametri
+- Validazione campi
+- Caricamento configurazioni esistenti
+- Help contestuale per ogni campo
+- Valori di default pre-caricati
+
+### 📦 Struttura
+
+- Script Python monolitico
+- Ambiente virtuale Python
+- Documentazione base
+
+---
+
+## [Roadmap] - Funzionalità Future
+
+### 🚀 Prossime Release
+
+#### v2.1.0 (Pianificato)
+- [ ] **Profili di configurazione**: Salva/carica profili predefiniti
+- [ ] **Batch flash**: Flasha multipli dispositivi in sequenza
+- [ ] **Serial monitor integrato**: Leggi output ESP32 dalla GUI
+- [ ] **Verifica firmware**: Controlla hash del firmware prima del flash
+- [ ] **Storia flash**: Log di tutti i flash effettuati
+
+#### v2.2.0 (Pianificato)
+- [ ] **OTA Update**: Flash via WiFi (Over-The-Air)
+- [ ] **Backup/Restore**: Backup della flash completa
+- [ ] **Config upload automatico**: Carica config direttamente su ESP32
+- [ ] **Multi-lingua**: Interfaccia in italiano/inglese
+- [ ] **Dark mode**: Tema scuro per la GUI
+
+#### v3.0.0 (Futuro)
+- [ ] **Web interface**: Versione web della GUI
+- [ ] **Database**: Gestione centralizzata dei dispositivi
+- [ ] **API REST**: Integrazione con sistemi esterni
+- [ ] **Dashboard**: Monitoraggio dispositivi in tempo reale
+- [ ] **Analytics**: Statistiche e grafici dei dispositivi flashati
+
+---
+
+## 📝 Note di Versione
+
+### Compatibilità
+
+- **Python**: 3.7+
+- **OS**: macOS, Linux, Windows
+- **ESP32**: Tutti i modelli (ESP32, ESP32-S2, ESP32-C3, etc.)
+- **Flash size**: 1MB, 2MB, 4MB, 8MB, 16MB
+
+### Problemi Noti
+
+Nessun problema noto in questa versione.
+
+### Come Contribuire
+
+1. Fork il repository
+2. Crea un branch per la tua feature (`git checkout -b feature/amazing-feature`)
+3. Commit le modifiche (`git commit -m 'Add amazing feature'`)
+4. Push al branch (`git push origin feature/amazing-feature`)
+5. Apri una Pull Request
+
+---
+
+## 🏆 Credits
+
+- **Sviluppato per**: A-A-Milano-Smart-Park
+- **Repository**: https://github.com/A-A-Milano-Smart-Park/msp-firmware
+- **Autore**: Config Generator Team
+- **Licenza**: Vedere repository principale
+
+---
+
+## 📞 Supporto
+
+- **Issues**: https://github.com/A-A-Milano-Smart-Park/msp-firmware/issues
+- **Documentation**: [README.md](README.md)
+- **Quick Start**: [QUICK_START.md](QUICK_START.md)
+- **Examples**: [CUSTOMIZATION_EXAMPLES.md](CUSTOMIZATION_EXAMPLES.md)
+
+---
+
+**Ultimo aggiornamento**: 2026-01-12

--- a/config_generator/CUSTOMIZATION_GUIDE.md
+++ b/config_generator/CUSTOMIZATION_GUIDE.md
@@ -1,0 +1,249 @@
+# Guida alla Personalizzazione
+
+Questa guida ti mostra come personalizzare facilmente l'applicazione modificando il file [config_data.py](config_data.py).
+
+## 📝 Struttura del File config_data.py
+
+Il file `config_data.py` contiene **TUTTE** le configurazioni centralizzate:
+
+```
+config_data.py
+├── DEFAULT_VALUES          # Valori di default per tutti i campi
+├── WIFI_POWER_VALUES      # Valori consentiti per WiFi Power
+├── AVERAGE_MEASUREMENTS   # Valori consentiti per Average Measurements
+├── GAS_SENSOR_TYPES       # Tipi di sensori gas
+├── HELP_TEXTS             # Testi di aiuto per la GUI
+├── JSON_HELP_TEXTS        # Testi di aiuto nel file JSON generato
+└── GITHUB_REPO            # Repository GitHub per download firmware
+```
+
+## ✏️ Esempi di Personalizzazione
+
+### 1. Cambiare i Valori di Default
+
+**Scenario**: Vuoi che il WiFi Power di default sia 15 invece di 17
+
+**File**: `config_data.py`
+**Linea**: ~13
+
+```python
+DEFAULT_VALUES = {
+    # ...
+    "wifi_power": "15",  # Cambiato da "17" a "15"
+    # ...
+}
+```
+
+### 2. Modificare i Testi di Help
+
+**Scenario**: Vuoi un testo di aiuto più dettagliato per il campo SSID
+
+**File**: `config_data.py`
+**Linea**: ~53
+
+```python
+HELP_TEXTS = {
+    "ssid": """Nome della rete WiFi a cui il dispositivo si connetterà.
+
+    IMPORTANTE:
+    - La rete deve essere a 2.4GHz (NON 5GHz)
+    - Evita caratteri speciali nel nome della rete
+    - Lunghezza massima: 32 caratteri
+
+    Esempio: MiaReteWiFi""",
+    # ...
+}
+```
+
+### 3. Aggiungere Nuovi Valori Consentiti
+
+**Scenario**: Vuoi aggiungere un nuovo valore per WiFi Power
+
+**File**: `config_data.py`
+**Linea**: ~46
+
+```python
+WIFI_POWER_VALUES = [
+    "-1", "2", "5", "7", "8.5", "11", "13", "15", "17", "18.5", "19", "19.5",
+    "20"  # NUOVO VALORE AGGIUNTO
+]
+```
+
+### 4. Cambiare Repository GitHub
+
+**Scenario**: Vuoi scaricare firmware da un repository diverso
+
+**File**: `config_data.py`
+**Linea**: ~70
+
+```python
+GITHUB_REPO = "tuo-username/tuo-repository"  # Cambiato
+```
+
+### 5. Modificare Valori di Calibrazione di Default
+
+**Scenario**: Hai nuovi valori standard per i sensori MICS
+
+**File**: `config_data.py`
+**Linea**: ~20
+
+```python
+DEFAULT_VALUES = {
+    # ...
+    # MICS Calibration Values
+    "mics_cal_red": "1000",  # Cambiato da "955"
+    "mics_cal_ox": "950",    # Cambiato da "900"
+    "mics_cal_nh3": "200",   # Cambiato da "163"
+    # ...
+}
+```
+
+### 6. Cambiare Altitudine di Default
+
+**Scenario**: I tuoi dispositivi sono installati a Roma invece che Milano
+
+**File**: `config_data.py`
+**Linea**: ~19
+
+```python
+DEFAULT_VALUES = {
+    # ...
+    "sea_level_altitude": "21.00",  # Altitudine media di Roma
+    # ...
+}
+```
+
+E aggiorna anche l'help text:
+
+```python
+HELP_TEXTS = {
+    # ...
+    "sea_level_altitude": "Altitudine sul livello del mare della posizione del dispositivo in metri\n\nQuesto valore è necessario per la calibrazione corretta della pressione atmosferica\n\nEsempio: 21.0 metri è l'altitudine media di Roma, Italia",
+    # ...
+}
+```
+
+## 🔧 Modifiche Avanzate
+
+### Aggiungere un Nuovo Tipo di Sensore
+
+**File**: `config_data.py`
+**Linea**: ~50
+
+```python
+GAS_SENSOR_TYPES = {
+    "MICS6814": 0,
+    "MICS4514 (DFRobot SEN0377)": 1,
+    "NUOVO_SENSORE": 2,  # AGGIUNTO
+}
+```
+
+### Modificare Parametri di Flash ESP32
+
+**File**: `config_data.py`
+**Linea**: ~80
+
+```python
+# Aumenta la velocità di flash (se il tuo ESP32 lo supporta)
+FLASH_BAUDRATE = 1500000  # Cambiato da 921600
+
+# Cambia il flash mode
+FLASH_MODE = "qio"  # Cambiato da "dio"
+```
+
+## 🚨 Attenzione
+
+### NON Modificare
+
+❌ **NON modificare** il file `config_generator_gui.py` a meno che tu non voglia cambiare la logica dell'interfaccia
+
+❌ **NON cambiare** i nomi delle chiavi in `DEFAULT_VALUES` (solo i valori)
+
+### Esempio SBAGLIATO:
+```python
+DEFAULT_VALUES = {
+    "ssid_wifi": "",  # ❌ SBAGLIATO! Non cambiare il nome della chiave
+}
+```
+
+### Esempio CORRETTO:
+```python
+DEFAULT_VALUES = {
+    "ssid": "MiaReteDefault",  # ✅ CORRETTO! Cambia solo il valore
+}
+```
+
+## ✅ Testing delle Modifiche
+
+Dopo aver fatto modifiche a `config_data.py`:
+
+1. Salva il file
+2. Riavvia l'applicazione:
+   ```bash
+   ./run_gui.sh  # macOS/Linux
+   run_gui.bat   # Windows
+   ```
+3. Verifica che le modifiche siano visibili nella GUI
+
+## 📋 Checklist Modifiche
+
+Prima di salvare le modifiche, verifica:
+
+- [ ] Hai modificato solo i **valori**, non i **nomi** delle chiavi
+- [ ] Le stringhe sono racchiuse tra virgolette (`"` o `'`)
+- [ ] I numeri NON hanno virgolette (es: `17` non `"17"`)
+- [ ] I booleani sono `True` o `False` (maiuscolo)
+- [ ] Hai aggiornato HELP_TEXTS se hai cambiato DEFAULT_VALUES
+- [ ] Il file è salvato con encoding UTF-8
+- [ ] Non ci sono errori di sintassi Python
+
+## 🐛 Risoluzione Problemi
+
+### Errore: "SyntaxError" all'avvio
+
+**Causa**: Errore di sintassi in `config_data.py`
+
+**Soluzione**:
+1. Controlla che tutte le stringhe siano chiuse correttamente
+2. Verifica che le virgole siano al posto giusto
+3. Assicurati che le parentesi quadre/graffe siano bilanciate
+
+### Errore: "KeyError"
+
+**Causa**: Hai cambiato il nome di una chiave in `DEFAULT_VALUES`
+
+**Soluzione**:
+1. Ripristina il nome originale della chiave
+2. Modifica solo il valore associato
+
+### I cambiamenti non si vedono
+
+**Causa**: L'applicazione usa ancora la versione in cache
+
+**Soluzione**:
+1. Chiudi completamente l'applicazione
+2. Riavviala con `./run_gui.sh` o `run_gui.bat`
+
+## 📞 Supporto
+
+Se hai dubbi sulle personalizzazioni, consulta:
+- [README.md](README.md) - Documentazione principale
+- [config_data.py](config_data.py) - Il file stesso (ben commentato)
+- GitHub Issues del progetto
+
+## 💡 Suggerimenti
+
+1. **Fai un backup**: Prima di modifiche importanti, copia `config_data.py` in `config_data.py.backup`
+
+2. **Modifiche incrementali**: Fai una modifica alla volta e testa
+
+3. **Commenta le modifiche**: Aggiungi commenti per ricordare le tue personalizzazioni
+   ```python
+   "wifi_power": "15",  # Modificato il 2024-01-12 per dispositivi outdoor
+   ```
+
+4. **Versiona**: Se usi git, committa le modifiche con messaggi chiari
+   ```bash
+   git add config_data.py
+   git commit -m "Update default WiFi power to 15dBm"
+   ```

--- a/config_generator/QUICK_START.md
+++ b/config_generator/QUICK_START.md
@@ -1,0 +1,230 @@
+# 🚀 Quick Start Guide - MSP Config Generator
+
+## ⚡ Avvio Rapido
+
+### macOS / Linux
+```bash
+cd config_generator
+./run_gui.sh
+```
+
+### Windows
+```cmd
+cd config_generator
+run_gui.bat
+```
+Oppure doppio click su `run_gui.bat`
+
+---
+
+## 🎯 Workflow Completo
+
+### 1️⃣ Genera Configurazione
+1. Apri la tab **"📝 Configuration"**
+2. Compila i campi richiesti:
+   - **SSID**: Nome WiFi
+   - **Password**: Password WiFi
+     - 💡 **Tip**: Usa il pulsante 👁️ per vedere la password in chiaro e verificarla!
+   - **Device ID**: Es. MSP001
+   - **Upload Server**: URL del server
+3. Clicca **"Generate Config"**
+4. Salva come `config_v4.json`
+
+### 2️⃣ Flash ESP32
+1. **Collega ESP32** via USB
+2. Vai alla tab **"⚡ ESP32 Flash"**
+3. Clicca **"🔄 Refresh"** per vedere le porte
+4. Seleziona la porta del tuo ESP32
+5. Clicca **"🔍 Detect"** per verificare il chip
+6. Clicca **"📥 Download Latest Release from GitHub"**
+   - Il firmware verrà scaricato in `~/Downloads/msp-firmware/`
+7. Clicca **"⚡ Flash Firmware"**
+8. Attendi il completamento
+
+### 3️⃣ Verifica
+Il log mostrerà:
+```
+✅ Flash completato con successo!
+```
+
+---
+
+## 🔧 Personalizzazione Rapida
+
+### Cambiare Valori di Default
+
+Apri **[config_data.py](config_data.py)** e modifica:
+
+```python
+DEFAULT_VALUES = {
+    "ssid": "MyWiFi",              # ← Cambia qui il WiFi di default
+    "wifi_power": "17",            # ← Cambia potenza WiFi
+    "device_id": "MSP001",         # ← Device ID di default
+    "sea_level_altitude": "122.00", # ← Altitudine di default
+    # ... altri valori
+}
+```
+
+### Cambiare Testi di Help
+
+```python
+HELP_TEXTS = {
+    "ssid": "Il tuo nuovo testo di help personalizzato",
+    # ... altri help text
+}
+```
+
+### Cambiare Repository GitHub
+
+```python
+GITHUB_REPO = "TuoUsername/tuo-repo"
+```
+
+Salva il file e riavvia la GUI!
+
+---
+
+## 🧪 Test del Sistema
+
+Esegui lo script di test per verificare che tutto funzioni:
+
+```bash
+cd config_generator
+source venv/bin/activate
+python test_modules.py
+```
+
+Output atteso:
+```
+🎯 Test superati: 5/5
+🎉 Tutti i test sono passati!
+```
+
+---
+
+## 📝 Esempi di Configurazione
+
+### Configurazione Base
+- **SSID**: MyWiFiNetwork
+- **Password**: ********
+- **Device ID**: MSP001
+- **WiFi Power**: 17 dBm
+- **Upload Server**: https://api.example.com/upload
+
+### Configurazione con Modem
+1. Abilita **"Use Modem"**
+2. Inserisci **"Modem APN"**: Es. `mobile.vodafone.it`
+
+### Configurazione Sensori
+- **Gas Sensor Type**: MICS6814 o MICS4514
+- **O3 Zero Value**: -1 (auto calibration)
+- **Average Measurements**: 30 (default)
+
+---
+
+## ⚠️ Risoluzione Problemi
+
+### Porta COM non trovata
+
+**macOS**:
+```bash
+ls /dev/tty.*
+# Cerca /dev/cu.usbserial-* o /dev/cu.SLAB_USBtoUART
+```
+
+**Linux**:
+```bash
+ls /dev/ttyUSB*
+# Aggiungi permessi: sudo chmod 666 /dev/ttyUSB0
+```
+
+**Windows**:
+- Apri **Gestione Dispositivi**
+- Cerca **Porte COM**
+- Installa driver CH340 o CP2102 se necessario
+
+### Errore durante Flash
+
+1. **Disconnetti e riconnetti** l'ESP32
+2. Prova a tenere premuto il bottone **BOOT** durante il flash
+3. Clicca **"🗑️ Erase Flash"** prima di flashare
+4. Riduci la velocità baud (modifica `config_data.py`: `FLASH_BAUDRATE = 115200`)
+
+### GUI non si avvia
+
+**macOS/Linux**:
+```bash
+# Reinstalla dipendenze
+source venv/bin/activate
+pip install --force-reinstall -r requirements.txt
+```
+
+**Ubuntu/Debian** (se manca tkinter):
+```bash
+sudo apt-get install python3-tk
+```
+
+---
+
+## 📂 File Importanti
+
+| File | Descrizione | Modifica? |
+|------|-------------|-----------|
+| `config_data.py` | ⚙️ Configurazione (valori, help, costanti) | ✅ **SÌ** |
+| `config_generator_gui.py` | 🖥️ GUI principale | ❌ No (a meno che tu voglia aggiungere funzionalità) |
+| `esp32_utils.py` | 🔧 Utility ESP32 | ❌ No |
+| `github_utils.py` | 📥 Utility GitHub | ❌ No |
+| `run_gui.sh` | 🚀 Launcher macOS/Linux | ❌ No |
+| `test_modules.py` | 🧪 Script di test | ❌ No |
+
+---
+
+## 💡 Tips & Tricks
+
+### 1. Salva Template di Configurazione
+- Crea diverse configurazioni per diversi setup
+- Salva come `config_office.json`, `config_outdoor.json`, etc.
+- Usa **"Load Config"** per caricarle velocemente
+
+### 2. Flash Multipli
+- Tieni il firmware scaricato in `~/Downloads/msp-firmware/`
+- Usa **"📂 Select Local .bin File"** per flash veloci
+- Non serve riscaricarlo ogni volta
+
+### 3. Backup Prima di Flash
+- Salva sempre la configurazione corrente
+- Annota i valori di calibrazione MICS
+- Tieni una copia del firmware funzionante
+
+### 4. Verifica Flash
+Dopo il flash, apri il **Serial Monitor** per verificare:
+```bash
+# macOS/Linux
+screen /dev/cu.usbserial-14230 115200
+
+# Windows (usa PuTTY o Arduino IDE Serial Monitor)
+```
+
+---
+
+## 🆘 Supporto
+
+- **GitHub Issues**: https://github.com/A-A-Milano-Smart-Park/msp-firmware/issues
+- **Test Suite**: `python test_modules.py`
+- **Documentazione completa**: [README.md](README.md)
+
+---
+
+## ✅ Checklist Flash Completo
+
+- [ ] ESP32 collegato via USB
+- [ ] Porta COM rilevata e selezionata
+- [ ] Chip info rilevato correttamente
+- [ ] Firmware scaricato o selezionato
+- [ ] Flash completato con successo
+- [ ] LED ESP32 lampeggia (boot corretto)
+- [ ] Serial Monitor mostra output (opzionale)
+
+---
+
+**Buon lavoro! 🚀**

--- a/config_generator/README.md
+++ b/config_generator/README.md
@@ -1,0 +1,285 @@
+# MSP Firmware Config Generator & Flasher
+
+Una GUI cross-platform completa per generare file `config_v4.json` e flashare il firmware ESP32 per il progetto MSP.
+
+## 🎯 Caratteristiche
+
+### ✅ Configurazione JSON
+- Interfaccia grafica intuitiva con tutti i parametri di configurazione
+- Validazione automatica dei campi
+- Help contestuale per ogni campo
+- Valori di default pre-caricati
+- Possibilità di caricare e modificare configurazioni esistenti
+
+### ⚡ Flash ESP32
+- **Rilevamento automatico** delle porte COM disponibili
+- **Rilevamento automatico** della dimensione flash ESP32
+- **Download automatico** dell'ultima release da GitHub
+- **Flash firmware** con barra di progresso in tempo reale
+- **Erase flash** per ripristino completo
+- Log dettagliato di tutte le operazioni
+
+### 🏗️ Architettura Modulare
+- **config_data.py**: Tutti i valori di default, help text e costanti (facilmente modificabile)
+- **config_generator_gui.py**: Interfaccia grafica principale
+- **esp32_utils.py**: Utilità per comunicazione con ESP32
+- **github_utils.py**: Utilità per download da GitHub
+
+## 📦 Installazione
+
+### Prerequisiti
+- Python 3.7 o superiore
+- pip (package manager Python)
+
+### 1. Creare l'ambiente virtuale e installare le dipendenze
+
+#### macOS/Linux:
+```bash
+cd config_generator
+./run_gui.sh
+```
+Lo script creerà automaticamente l'ambiente virtuale e installerà tutte le dipendenze!
+
+#### Windows:
+Doppio click su `run_gui.bat` oppure:
+```cmd
+cd config_generator
+run_gui.bat
+```
+
+### 2. Installazione manuale (opzionale)
+
+Se preferisci installare manualmente:
+
+```bash
+cd config_generator
+python3 -m venv venv
+source venv/bin/activate  # Linux/macOS
+# oppure
+venv\Scripts\activate     # Windows
+
+pip install -r requirements.txt
+python config_generator_gui.py
+```
+
+## 🚀 Utilizzo
+
+### Avvio Rapido
+```bash
+./run_gui.sh  # macOS/Linux
+run_gui.bat   # Windows
+```
+
+### Tab 1: Configuration (📝)
+
+#### Funzionalità
+
+1. **Generate Config**: Compila i campi e genera il file JSON
+   - Tutti i valori vengono validati automaticamente
+   - Puoi scegliere dove salvare il file
+
+2. **Load Config**: Carica un file di configurazione esistente per modificarlo
+   - Tutti i valori vengono caricati nella GUI
+   - Puoi modificare e salvare con un nuovo nome
+
+3. **Reset to Defaults**: Ripristina tutti i valori di default
+
+4. **Help (?)**: Ogni campo ha un pulsante con informazioni dettagliate
+
+5. **Password Toggle (👁️)**: Mostra/nascondi password WiFi in chiaro
+   - Click sull'icona 👁️ per visualizzare la password
+   - Click sull'icona 🔒 per nasconderla nuovamente
+   - Aiuta a verificare che la password sia stata inserita correttamente
+
+#### Sezioni di Configurazione
+
+- **Network Settings**: SSID, Password, WiFi Power
+- **Device Settings**: Device ID, Upload Server
+- **Sensor Settings**: Tipo sensore gas, calibrazione O3, misurazioni medie, altitudine
+- **MICS Calibration Values**: Valori di calibrazione per sensori RED, OX, NH3
+- **MICS Measurement Offsets**: Offset per le misurazioni
+- **Compensation Factors**: Fattori di compensazione per umidità, temperatura, pressione
+- **Modem Settings**: Configurazione modem cellulare (opzionale)
+- **Time Settings**: Server NTP e timezone
+- **Firmware Settings**: Auto upgrade del firmware
+
+### Tab 2: ESP32 Flash (⚡)
+
+#### 1. Selezione Dispositivo
+- **Porta COM**: Dropdown con tutte le porte seriali disponibili
+- **🔄 Refresh**: Aggiorna la lista delle porte
+- **🔍 Detect**: Rileva automaticamente le informazioni del chip ESP32
+  - Tipo di chip (ESP32, ESP32-S2, ESP32-C3, etc.)
+  - Indirizzo MAC
+  - Dimensione della flash
+
+#### 2. Download Firmware
+Hai due opzioni:
+
+**Opzione A: Download da GitHub (Consigliata)**
+- Clicca su **"📥 Download Latest Release from GitHub"**
+- Lo script scaricherà automaticamente l'ultima release dal repository
+- Il file verrà salvato in `~/Downloads/msp-firmware/`
+- Mostra la versione scaricata
+
+**Opzione B: File Locale**
+- Clicca su **"📂 Select Local .bin File"**
+- Seleziona un file `.bin` già presente sul tuo computer
+
+#### 3. Flash Firmware
+- Clicca su **"⚡ Flash Firmware"**
+- Conferma l'operazione
+- Il log mostrerà il progresso in tempo reale
+- Al termine riceverai una notifica di successo o errore
+
+#### 4. Erase Flash (Opzionale)
+- Clicca su **"🗑️ Erase Flash"** per cancellare completamente la memoria
+- Utile per ripristini completi o troubleshooting
+
+## 📝 Personalizzazione
+
+### Modificare Valori di Default e Help Text
+
+Apri il file [config_data.py](config_data.py) e modifica:
+
+```python
+# Valori di default
+DEFAULT_VALUES = {
+    "ssid": "",  # Cambia qui il valore di default
+    "wifi_power": "17",  # Modifica il WiFi power di default
+    # ... altri valori
+}
+
+# Testi di help
+HELP_TEXTS = {
+    "ssid": "Il tuo testo di help personalizzato qui",
+    # ... altri help text
+}
+```
+
+### Modificare Valori Consentiti
+
+```python
+WIFI_POWER_VALUES = ["-1", "2", "5", "7", "8.5", "11", "13", "15", "17", "18.5", "19", "19.5"]
+# Aggiungi o rimuovi valori dalla lista
+```
+
+### Modificare Repository GitHub
+
+```python
+GITHUB_REPO = "A-A-Milano-Smart-Park/msp-firmware"
+# Cambia con il tuo repository
+```
+
+## 🛠️ Struttura File
+
+```
+config_generator/
+├── config_data.py              # ⚙️ CONFIGURAZIONE (modifica qui!)
+├── config_generator_gui.py     # 🖥️ GUI principale
+├── esp32_utils.py             # 🔧 Utilità ESP32
+├── github_utils.py            # 📥 Utilità GitHub
+├── requirements.txt           # 📦 Dipendenze Python
+├── run_gui.sh                # 🚀 Launcher macOS/Linux
+├── run_gui.bat               # 🚀 Launcher Windows
+├── README.md                 # 📖 Questo file
+└── venv/                     # 🐍 Ambiente virtuale Python
+```
+
+## 📋 Dipendenze
+
+- **tkinter**: GUI (incluso in Python)
+- **pyserial**: Comunicazione seriale con ESP32
+- **esptool**: Tool per flash ESP32
+- **requests**: Download da GitHub
+
+## 🔧 Risoluzione Problemi
+
+### Porte seriali non rilevate
+
+**macOS:**
+- Assicurati di avere i driver CH340/CP2102 installati
+- Controlla con: `ls /dev/tty.*`
+
+**Linux:**
+- Aggiungi il tuo utente al gruppo `dialout`:
+  ```bash
+  sudo usermod -a -G dialout $USER
+  ```
+- Riavvia la sessione
+
+**Windows:**
+- Installa i driver CH340 o CP2102
+- Verifica in Gestione Dispositivi
+
+### Errore "Permission denied" durante il flash
+
+**macOS/Linux:**
+```bash
+sudo chmod 666 /dev/ttyUSB0  # o la tua porta
+```
+
+### tkinter non trovato
+
+**Ubuntu/Debian:**
+```bash
+sudo apt-get install python3-tk
+```
+
+**Fedora:**
+```bash
+sudo dnf install python3-tkinter
+```
+
+### Errore durante il download da GitHub
+
+- Verifica la connessione internet
+- Controlla che il repository sia pubblico
+- GitHub potrebbe avere rate limiting (aspetta qualche minuto)
+
+## 🎓 Esempi di Utilizzo
+
+### Workflow Completo
+
+1. **Avvia l'applicazione**: `./run_gui.sh`
+2. **Tab Configuration**:
+   - Compila SSID e Password WiFi
+   - Inserisci Device ID (es: MSP001)
+   - Inserisci Upload Server URL
+   - Modifica altri parametri se necessario
+   - Clicca "Generate Config" e salva come `config_v4.json`
+3. **Tab ESP32 Flash**:
+   - Collega ESP32 via USB
+   - Clicca "🔄 Refresh" per vedere la porta
+   - Clicca "🔍 Detect" per verificare il chip
+   - Clicca "📥 Download Latest Release from GitHub"
+   - Clicca "⚡ Flash Firmware"
+   - Attendi il completamento
+
+### Solo Generazione Config
+
+Se vuoi solo generare il file di configurazione senza flashare:
+1. Usa solo la Tab "Configuration"
+2. Compila i campi necessari
+3. Genera e salva il file JSON
+
+### Solo Flash Firmware
+
+Se hai già il firmware `.bin`:
+1. Vai alla Tab "ESP32 Flash"
+2. Seleziona la porta
+3. Clicca "📂 Select Local .bin File"
+4. Clicca "⚡ Flash Firmware"
+
+## 📄 Licenza
+
+Questo progetto fa parte del repository MSP Firmware.
+
+## 🤝 Contributi
+
+Per contribuire o segnalare problemi, visita:
+https://github.com/A-A-Milano-Smart-Park/msp-firmware
+
+## 📞 Supporto
+
+Per domande o problemi, apri una issue su GitHub.

--- a/config_generator/config_data.py
+++ b/config_generator/config_data.py
@@ -1,0 +1,156 @@
+"""
+Configuration data module
+Contiene tutti i valori di default, help text e costanti per il Config Generator
+Modifica questo file per cambiare i valori di default e i testi di help
+"""
+
+# ============================================================================
+# VALORI DI DEFAULT
+# ============================================================================
+
+DEFAULT_VALUES = {
+    # Network Settings
+    "ssid": "",
+    "password": "",
+    "wifi_power": "17",
+
+    # Device Settings
+    "device_id": "",
+    "upload_server": "",
+
+    # Sensor Settings
+    "gas_sensor_type": "MICS6814",
+    "o3_zero_value": "-1",
+    "average_measurements": "30",
+    "sea_level_altitude": "122.00",
+
+    # MICS Calibration Values
+    "mics_cal_red": "955",
+    "mics_cal_ox": "900",
+    "mics_cal_nh3": "163",
+
+    # MICS Measurement Offsets
+    "mics_offset_red": "0",
+    "mics_offset_ox": "0",
+    "mics_offset_nh3": "0",
+
+    # Compensation Factors
+    "comp_h": "0.6",
+    "comp_t": "1.352",
+    "comp_p": "0.0132",
+
+    # Modem Settings
+    "use_modem": False,
+    "modem_apn": "",
+
+    # Time Settings
+    "ntp_server": "pool.ntp.org",
+    "timezone": "GMT0",
+
+    # Firmware Settings
+    "fw_auto_upgrade": True,
+}
+
+# ============================================================================
+# VALORI CONSENTITI (per dropdown/combobox)
+# ============================================================================
+
+WIFI_POWER_VALUES = ["-1", "2", "5", "7", "8.5", "11", "13", "15", "17", "18.5", "19", "19.5"]
+
+AVERAGE_MEASUREMENTS_VALUES = ["1", "2", "3", "4", "5", "6", "10", "12", "15", "20", "30", "60"]
+
+GAS_SENSOR_TYPES = {
+    "MICS6814": 0,
+    "MICS4514 (DFRobot SEN0377)": 1
+}
+
+# ============================================================================
+# TESTI DI HELP
+# ============================================================================
+
+HELP_TEXTS = {
+    # Network Settings
+    "ssid": "Nome della rete WiFi a cui il dispositivo si connetterà",
+    "password": "Password della rete WiFi",
+    "wifi_power": "Potenza del segnale WiFi. Valori accettati: -1, 2, 5, 7, 8.5, 11, 13, 15, 17, 18.5, 19, 19.5 dBm\n\nValori più alti = maggiore portata ma maggiore consumo",
+
+    # Device Settings
+    "device_id": "Identificatore univoco del dispositivo (es: MSP001, MSP002, etc.)\n\nQuesto ID viene usato per identificare il dispositivo nel sistema",
+    "upload_server": "URL del server dove verranno caricati i dati delle misurazioni\n\nFormato: http://server.com/api/upload o https://server.com/api/upload",
+
+    # Sensor Settings
+    "gas_sensor_type": "Tipo di sensore gas installato sul dispositivo:\n\n0 = MICS6814 (sensore standard)\n1 = MICS4514 (DFRobot SEN0377)\n\nSeleziona il tipo corretto in base all'hardware installato",
+    "o3_zero_value": "Valore di calibrazione zero per il sensore O3\n\nUsa -1 per la calibrazione automatica\nUsa un valore specifico se hai già calibrato il sensore",
+    "average_measurements": "Numero di misurazioni da mediare prima di inviare i dati\n\nValori accettati: 1, 2, 3, 4, 5, 6, 10, 12, 15, 20, 30, 60\n\nValori più alti = dati più stabili ma aggiornamenti meno frequenti",
+    "sea_level_altitude": "Altitudine sul livello del mare della posizione del dispositivo in metri\n\nQuesto valore è necessario per la calibrazione corretta della pressione atmosferica\n\nEsempio: 122.0 metri è l'altitudine media di Milano, Italia",
+
+    # MICS Calibration Values
+    "mics_cal_red": "Valore di calibrazione per il sensore MICS RED (gas riducenti)\n\nQuesto valore viene ottenuto durante la calibrazione del sensore",
+    "mics_cal_ox": "Valore di calibrazione per il sensore MICS OX (gas ossidanti)\n\nQuesto valore viene ottenuto durante la calibrazione del sensore",
+    "mics_cal_nh3": "Valore di calibrazione per il sensore MICS NH3 (ammoniaca)\n\nQuesto valore viene ottenuto durante la calibrazione del sensore",
+
+    # MICS Measurement Offsets
+    "mics_offset_red": "Offset di correzione per le misurazioni del sensore RED\n\nUsa 0 se non necessario, altrimenti inserisci il valore di offset calcolato",
+    "mics_offset_ox": "Offset di correzione per le misurazioni del sensore OX\n\nUsa 0 se non necessario, altrimenti inserisci il valore di offset calcolato",
+    "mics_offset_nh3": "Offset di correzione per le misurazioni del sensore NH3\n\nUsa 0 se non necessario, altrimenti inserisci il valore di offset calcolato",
+
+    # Compensation Factors
+    "comp_h": "Fattore di compensazione per l'umidità\n\nValore di default: 0.6\nModifica solo se hai valori di calibrazione specifici",
+    "comp_t": "Fattore di compensazione per la temperatura\n\nValore di default: 1.352\nModifica solo se hai valori di calibrazione specifici",
+    "comp_p": "Fattore di compensazione per la pressione\n\nValore di default: 0.0132\nModifica solo se hai valori di calibrazione specifici",
+
+    # Modem Settings
+    "use_modem": "Abilita l'uso del modem cellulare per la connettività\n\nSeleziona questa opzione se il dispositivo usa una connessione cellulare invece del WiFi",
+    "modem_apn": "APN (Access Point Name) del provider cellulare\n\nNecessario solo se 'Use Modem' è abilitato\nContatta il tuo provider per ottenere l'APN corretto",
+
+    # Time Settings
+    "ntp_server": "Indirizzo del server NTP per la sincronizzazione dell'ora\n\nDefault: pool.ntp.org (server NTP pubblico)\nPuoi usare server NTP locali per maggiore affidabilità",
+    "timezone": "Definizione del fuso orario in formato TZ standard\n\nEsempi:\n- CET-1CEST,M3.5.0,M10.5.0/3 (Europa/Roma)\n- GMT0 (Greenwich)\n- EST5EDT,M3.2.0,M11.1.0 (US Eastern)\n\nDettagli: https://www.gnu.org/software/libc/manual/html_node/TZ-Variable.html",
+
+    # Firmware Settings
+    "fw_auto_upgrade": "Abilita l'aggiornamento automatico del firmware\n\nSe abilitato, il dispositivo controllerà e installerà automaticamente nuove versioni del firmware quando disponibili",
+}
+
+# ============================================================================
+# TESTI DI HELP PER IL FILE JSON GENERATO
+# ============================================================================
+
+JSON_HELP_TEXTS = {
+    "wifi_power": "Accepted values: -1, 2, 5, 7, 8.5, 11, 13, 15, 17, 18.5, 19, 19.5 dBm",
+    "average_measurements": "Accepted values: 1, 2, 3, 4, 5, 6, 10, 12, 15, 20, 30, 60",
+    "sea_level_altitude": "Value in meters, must be changed according to device location. 122.0 meters is the average altitude in Milan, Italy",
+    "timezone": "Standard tz timezone definition. More details at https://www.gnu.org/software/libc/manual/html_node/TZ-Variable.html",
+    "gas_sensor_type": "Gas sensor type: 0 = MICS6814, 1 = MICS4514 (DFRobot SEN0377)"
+}
+
+# ============================================================================
+# CONFIGURAZIONE GITHUB
+# ============================================================================
+
+GITHUB_REPO = "A-A-Milano-Smart-Park/msp-firmware"
+GITHUB_API_URL = f"https://api.github.com/repos/{GITHUB_REPO}/releases/latest"
+
+# ============================================================================
+# CONFIGURAZIONE FLASH ESP32
+# ============================================================================
+
+# Parametri di flash per ESP32
+FLASH_BAUDRATE = 921600
+FLASH_MODE = "dio"
+FLASH_FREQ = "40m"
+
+# Dimensioni flash supportate (in MB)
+FLASH_SIZES = {
+    0x100000: "1MB",
+    0x200000: "2MB",
+    0x400000: "4MB",
+    0x800000: "8MB",
+    0x1000000: "16MB",
+}
+
+# Indirizzi di memoria per il flash (ESP32 standard)
+FLASH_ADDRESSES = {
+    "bootloader": "0x1000",
+    "partitions": "0x8000",
+    "app": "0x10000",
+}

--- a/config_generator/config_generator_gui.py
+++ b/config_generator/config_generator_gui.py
@@ -1,0 +1,801 @@
+#!/usr/bin/env python3
+"""
+MSP Firmware Config Generator - Versione Modulare
+A cross-platform GUI tool to generate config_v4.json files and flash ESP32
+"""
+
+import tkinter as tk
+from tkinter import ttk, messagebox, filedialog, scrolledtext
+import json
+import threading
+from pathlib import Path
+
+# Import moduli locali
+from config_data import (
+    DEFAULT_VALUES, WIFI_POWER_VALUES, AVERAGE_MEASUREMENTS_VALUES,
+    GAS_SENSOR_TYPES, HELP_TEXTS, JSON_HELP_TEXTS, GITHUB_REPO
+)
+from esp32_utils import (
+    get_available_ports, detect_flash_size, get_chip_info,
+    get_chip_info_verbose, flash_firmware, flash_firmware_package, erase_flash
+)
+from github_utils import (
+    get_latest_release_info, download_firmware_package,
+    get_release_version, get_release_notes
+)
+
+
+class ConfigGeneratorGUI:
+    def __init__(self, root):
+        self.root = root
+        self.root.title("MSP Firmware Config Generator & Flasher")
+        self.root.geometry("950x900")
+
+        # Variables
+        self.vars = {}
+        self.firmware_path = None  # Legacy: path singolo file .bin
+        self.firmware_files = None  # Nuovo: dizionario con tutti i file del package
+        self.release_info = None
+        self.detected_flash_size = "4MB"  # Flash size rilevata dal dispositivo
+
+        # Create notebook (tabs)
+        self.notebook = ttk.Notebook(self.root)
+        self.notebook.pack(fill=tk.BOTH, expand=True, padx=10, pady=10)
+
+        # Tab 1: Configuration
+        self.config_tab = ttk.Frame(self.notebook)
+        self.notebook.add(self.config_tab, text="📝 Configuration")
+
+        # Tab 2: ESP32 Flash
+        self.flash_tab = ttk.Frame(self.notebook)
+        self.notebook.add(self.flash_tab, text="⚡ ESP32 Flash")
+
+        # Create UI for both tabs
+        self.create_config_tab()
+        self.create_flash_tab()
+
+    def create_config_tab(self):
+        """Crea la tab di configurazione"""
+        # Create main canvas and scrollbar
+        main_frame = ttk.Frame(self.config_tab)
+        main_frame.pack(fill=tk.BOTH, expand=True, padx=5, pady=5)
+
+        canvas = tk.Canvas(main_frame)
+        scrollbar = ttk.Scrollbar(main_frame, orient="vertical", command=canvas.yview)
+        scrollable_frame = ttk.Frame(canvas)
+
+        scrollable_frame.bind(
+            "<Configure>",
+            lambda e: canvas.configure(scrollregion=canvas.bbox("all"))
+        )
+
+        canvas.create_window((0, 0), window=scrollable_frame, anchor="nw")
+        canvas.configure(yscrollcommand=scrollbar.set)
+
+        canvas.pack(side="left", fill="both", expand=True)
+        scrollbar.pack(side="right", fill="y")
+
+        # Title
+        title_label = ttk.Label(scrollable_frame, text="MSP Firmware Configuration",
+                               font=("Arial", 14, "bold"))
+        title_label.grid(row=0, column=0, columnspan=4, pady=10)
+
+        row = 1
+
+        # Network Settings
+        row = self.create_section(scrollable_frame, row, "Network Settings")
+        row = self.create_entry(scrollable_frame, row, "SSID", "ssid")
+        row = self.create_password_entry(scrollable_frame, row, "Password", "password")
+        row = self.create_combobox(scrollable_frame, row, "WiFi Power", "wifi_power",
+                                   WIFI_POWER_VALUES)
+
+        # Device Settings
+        row = self.create_section(scrollable_frame, row, "Device Settings")
+        row = self.create_entry(scrollable_frame, row, "Device ID", "device_id")
+        row = self.create_entry(scrollable_frame, row, "Upload Server", "upload_server")
+
+        # Sensor Settings
+        row = self.create_section(scrollable_frame, row, "Sensor Settings")
+        row = self.create_combobox(scrollable_frame, row, "Gas Sensor Type", "gas_sensor_type",
+                                   list(GAS_SENSOR_TYPES.keys()))
+        row = self.create_entry(scrollable_frame, row, "O3 Zero Value", "o3_zero_value")
+        row = self.create_combobox(scrollable_frame, row, "Average Measurements", "average_measurements",
+                                   AVERAGE_MEASUREMENTS_VALUES)
+        row = self.create_entry(scrollable_frame, row, "Sea Level Altitude (m)", "sea_level_altitude")
+
+        # MICS Calibration Values
+        row = self.create_section(scrollable_frame, row, "MICS Calibration Values")
+        row = self.create_entry(scrollable_frame, row, "RED Calibration", "mics_cal_red")
+        row = self.create_entry(scrollable_frame, row, "OX Calibration", "mics_cal_ox")
+        row = self.create_entry(scrollable_frame, row, "NH3 Calibration", "mics_cal_nh3")
+
+        # MICS Measurement Offsets
+        row = self.create_section(scrollable_frame, row, "MICS Measurement Offsets")
+        row = self.create_entry(scrollable_frame, row, "RED Offset", "mics_offset_red")
+        row = self.create_entry(scrollable_frame, row, "OX Offset", "mics_offset_ox")
+        row = self.create_entry(scrollable_frame, row, "NH3 Offset", "mics_offset_nh3")
+
+        # Compensation Factors
+        row = self.create_section(scrollable_frame, row, "Compensation Factors")
+        row = self.create_entry(scrollable_frame, row, "Humidity Compensation", "comp_h")
+        row = self.create_entry(scrollable_frame, row, "Temperature Compensation", "comp_t")
+        row = self.create_entry(scrollable_frame, row, "Pressure Compensation", "comp_p")
+
+        # Modem Settings
+        row = self.create_section(scrollable_frame, row, "Modem Settings (Optional)")
+        row = self.create_checkbox(scrollable_frame, row, "Use Modem", "use_modem")
+        row = self.create_entry(scrollable_frame, row, "Modem APN", "modem_apn")
+
+        # Time Settings
+        row = self.create_section(scrollable_frame, row, "Time Settings")
+        row = self.create_entry(scrollable_frame, row, "NTP Server", "ntp_server")
+        row = self.create_entry(scrollable_frame, row, "Timezone", "timezone")
+
+        # Firmware Settings
+        row = self.create_section(scrollable_frame, row, "Firmware Settings")
+        row = self.create_checkbox(scrollable_frame, row, "Auto Firmware Upgrade", "fw_auto_upgrade")
+
+        # Buttons
+        button_frame = ttk.Frame(scrollable_frame)
+        button_frame.grid(row=row, column=0, columnspan=4, pady=20)
+
+        ttk.Button(button_frame, text="Generate Config", command=self.generate_config).pack(side="left", padx=5)
+        ttk.Button(button_frame, text="Load Config", command=self.load_config).pack(side="left", padx=5)
+        ttk.Button(button_frame, text="Reset to Defaults", command=self.set_defaults).pack(side="left", padx=5)
+
+        # Set default values
+        self.set_defaults()
+
+    def create_flash_tab(self):
+        """Crea la tab per il flash ESP32"""
+        main_frame = ttk.Frame(self.flash_tab)
+        main_frame.pack(fill=tk.BOTH, expand=True, padx=10, pady=10)
+
+        # Title
+        title_label = ttk.Label(main_frame, text="ESP32 Firmware Flasher",
+                               font=("Arial", 14, "bold"))
+        title_label.pack(pady=10)
+
+        # Frame per selezione porta
+        port_frame = ttk.LabelFrame(main_frame, text="Selezione Dispositivo", padding=10)
+        port_frame.pack(fill=tk.X, pady=5)
+
+        ttk.Label(port_frame, text="Porta COM:").grid(row=0, column=0, sticky="w", padx=5, pady=5)
+
+        self.port_var = tk.StringVar()
+        self.port_combo = ttk.Combobox(port_frame, textvariable=self.port_var, width=50, state="readonly")
+        self.port_combo.grid(row=0, column=1, padx=5, pady=5)
+
+        ttk.Button(port_frame, text="🔄 Refresh", command=self.refresh_ports).grid(row=0, column=2, padx=5)
+        ttk.Button(port_frame, text="🔍 Detect", command=self.detect_device).grid(row=0, column=3, padx=5)
+
+        # Info dispositivo
+        info_frame = ttk.LabelFrame(main_frame, text="Informazioni Dispositivo", padding=10)
+        info_frame.pack(fill=tk.X, pady=5)
+
+        self.chip_info_text = tk.Text(info_frame, height=4, width=80, state='disabled')
+        self.chip_info_text.pack(fill=tk.X, padx=5, pady=5)
+
+        # Frame firmware
+        firmware_frame = ttk.LabelFrame(main_frame, text="Firmware", padding=10)
+        firmware_frame.pack(fill=tk.X, pady=5)
+
+        ttk.Button(firmware_frame, text="📥 Download Latest Release from GitHub",
+                  command=self.download_latest_firmware, width=40).pack(pady=5)
+
+        ttk.Label(firmware_frame, text="o").pack(pady=2)
+
+        ttk.Button(firmware_frame, text="📂 Select Local .bin File",
+                  command=self.select_local_firmware, width=40).pack(pady=5)
+
+        self.firmware_label = ttk.Label(firmware_frame, text="Nessun firmware selezionato",
+                                       foreground="gray")
+        self.firmware_label.pack(pady=5)
+
+        # Frame azioni
+        action_frame = ttk.LabelFrame(main_frame, text="Azioni", padding=10)
+        action_frame.pack(fill=tk.X, pady=5)
+
+        btn_frame = ttk.Frame(action_frame)
+        btn_frame.pack()
+
+        self.flash_btn = ttk.Button(btn_frame, text="⚡ Flash Firmware",
+                                    command=self.flash_device, state='disabled')
+        self.flash_btn.pack(side=tk.LEFT, padx=5)
+
+        ttk.Button(btn_frame, text="🗑️ Erase Flash", command=self.erase_device_flash).pack(side=tk.LEFT, padx=5)
+
+        # Log area
+        log_frame = ttk.LabelFrame(main_frame, text="Output Log", padding=5)
+        log_frame.pack(fill=tk.BOTH, expand=True, pady=5)
+
+        self.log_text = scrolledtext.ScrolledText(log_frame, height=15, width=80, state='disabled')
+        self.log_text.pack(fill=tk.BOTH, expand=True)
+
+        # Refresh ports iniziale
+        self.refresh_ports()
+
+    def create_section(self, parent, row, title):
+        """Create a section header"""
+        separator = ttk.Separator(parent, orient="horizontal")
+        separator.grid(row=row, column=0, columnspan=4, sticky="ew", pady=(15, 5))
+        row += 1
+
+        label = ttk.Label(parent, text=title, font=("Arial", 11, "bold"))
+        label.grid(row=row, column=0, columnspan=4, sticky="w", pady=(0, 8))
+        return row + 1
+
+    def create_entry(self, parent, row, label_text, var_name, show=None):
+        """Create a labeled entry with help text"""
+        label = ttk.Label(parent, text=label_text + ":")
+        label.grid(row=row, column=0, sticky="w", padx=5, pady=5)
+
+        self.vars[var_name] = tk.StringVar()
+        entry = ttk.Entry(parent, textvariable=self.vars[var_name], width=40, show=show)
+        entry.grid(row=row, column=1, sticky="ew", padx=5, pady=5)
+
+        help_text = HELP_TEXTS.get(var_name, "Nessun aiuto disponibile")
+        help_btn = ttk.Button(parent, text="?", width=3,
+                             command=lambda: messagebox.showinfo("Help", help_text))
+        help_btn.grid(row=row, column=2, padx=5, pady=5)
+
+        parent.columnconfigure(1, weight=1)
+        return row + 1
+
+    def create_password_entry(self, parent, row, label_text, var_name):
+        """Create a password entry with show/hide toggle button"""
+        label = ttk.Label(parent, text=label_text + ":")
+        label.grid(row=row, column=0, sticky="w", padx=5, pady=5)
+
+        self.vars[var_name] = tk.StringVar()
+        entry = ttk.Entry(parent, textvariable=self.vars[var_name], width=40, show="*")
+        entry.grid(row=row, column=1, sticky="ew", padx=5, pady=5)
+
+        # Toggle button per mostrare/nascondere password
+        def toggle_password():
+            if entry.cget('show') == '*':
+                entry.config(show='')
+                toggle_btn.config(text="🔒")
+            else:
+                entry.config(show='*')
+                toggle_btn.config(text="👁️")
+
+        toggle_btn = ttk.Button(parent, text="👁️", width=3, command=toggle_password)
+        toggle_btn.grid(row=row, column=2, padx=2, pady=5)
+
+        help_text = HELP_TEXTS.get(var_name, "Nessun aiuto disponibile")
+        help_btn = ttk.Button(parent, text="?", width=3,
+                             command=lambda: messagebox.showinfo("Help", help_text))
+        help_btn.grid(row=row, column=3, padx=5, pady=5)
+
+        parent.columnconfigure(1, weight=1)
+        return row + 1
+
+    def create_combobox(self, parent, row, label_text, var_name, values):
+        """Create a labeled combobox with help text"""
+        label = ttk.Label(parent, text=label_text + ":")
+        label.grid(row=row, column=0, sticky="w", padx=5, pady=5)
+
+        self.vars[var_name] = tk.StringVar()
+        combo = ttk.Combobox(parent, textvariable=self.vars[var_name], values=values,
+                            width=37, state="readonly")
+        combo.grid(row=row, column=1, sticky="ew", padx=5, pady=5)
+
+        help_text = HELP_TEXTS.get(var_name, "Nessun aiuto disponibile")
+        help_btn = ttk.Button(parent, text="?", width=3,
+                             command=lambda: messagebox.showinfo("Help", help_text))
+        help_btn.grid(row=row, column=2, padx=5, pady=5)
+
+        parent.columnconfigure(1, weight=1)
+        return row + 1
+
+    def create_checkbox(self, parent, row, label_text, var_name):
+        """Create a labeled checkbox with help text"""
+        label = ttk.Label(parent, text=label_text + ":")
+        label.grid(row=row, column=0, sticky="w", padx=5, pady=5)
+
+        self.vars[var_name] = tk.BooleanVar()
+        check = ttk.Checkbutton(parent, variable=self.vars[var_name])
+        check.grid(row=row, column=1, sticky="w", padx=5, pady=5)
+
+        help_text = HELP_TEXTS.get(var_name, "Nessun aiuto disponibile")
+        help_btn = ttk.Button(parent, text="?", width=3,
+                             command=lambda: messagebox.showinfo("Help", help_text))
+        help_btn.grid(row=row, column=2, padx=5, pady=5)
+
+        return row + 1
+
+    def set_defaults(self):
+        """Set default values from config_data"""
+        for key, value in DEFAULT_VALUES.items():
+            if key in self.vars:
+                self.vars[key].set(value)
+
+    def validate_and_get_config(self):
+        """Validate all fields and return config dictionary"""
+        try:
+            gas_sensor_text = self.vars["gas_sensor_type"].get()
+            gas_sensor_value = GAS_SENSOR_TYPES[gas_sensor_text]
+
+            config = {
+                "config": {
+                    "ssid": self.vars["ssid"].get(),
+                    "password": self.vars["password"].get(),
+                    "device_id": self.vars["device_id"].get(),
+                    "wifi_power": self.vars["wifi_power"].get() + "dBm",
+                    "o3_zero_value": int(self.vars["o3_zero_value"].get()),
+                    "average_measurements": int(self.vars["average_measurements"].get()),
+                    "sea_level_altitude": float(self.vars["sea_level_altitude"].get()),
+                    "upload_server": self.vars["upload_server"].get(),
+                    "mics_calibration_values": {
+                        "RED": int(self.vars["mics_cal_red"].get()),
+                        "OX": int(self.vars["mics_cal_ox"].get()),
+                        "NH3": int(self.vars["mics_cal_nh3"].get())
+                    },
+                    "mics_measurements_offsets": {
+                        "RED": int(self.vars["mics_offset_red"].get()),
+                        "OX": int(self.vars["mics_offset_ox"].get()),
+                        "NH3": int(self.vars["mics_offset_nh3"].get())
+                    },
+                    "compensation_factors": {
+                        "compH": float(self.vars["comp_h"].get()),
+                        "compT": float(self.vars["comp_t"].get()),
+                        "compP": float(self.vars["comp_p"].get())
+                    },
+                    "use_modem": self.vars["use_modem"].get(),
+                    "modem_apn": self.vars["modem_apn"].get(),
+                    "ntp_server": self.vars["ntp_server"].get(),
+                    "timezone": self.vars["timezone"].get(),
+                    "fw_auto_upgrade": self.vars["fw_auto_upgrade"].get(),
+                    "gas_sensor_type": gas_sensor_value
+                },
+                "help": JSON_HELP_TEXTS
+            }
+
+            return config
+        except ValueError as e:
+            messagebox.showerror("Validation Error", f"Invalid value in one of the fields: {e}")
+            return None
+
+    def generate_config(self):
+        """Generate and save the config file"""
+        config = self.validate_and_get_config()
+        if config is None:
+            return
+
+        file_path = filedialog.asksaveasfilename(
+            defaultextension=".json",
+            filetypes=[("JSON files", "*.json"), ("All files", "*.*")],
+            initialfile="config_v4.json"
+        )
+
+        if not file_path:
+            return
+
+        try:
+            with open(file_path, 'w') as f:
+                json.dump(config, f, indent=2)
+
+            messagebox.showinfo("Success", f"Configuration saved successfully to:\n{file_path}")
+        except Exception as e:
+            messagebox.showerror("Error", f"Failed to save configuration:\n{e}")
+
+    def load_config(self):
+        """Load an existing config file"""
+        file_path = filedialog.askopenfilename(
+            filetypes=[("JSON files", "*.json"), ("All files", "*.*")]
+        )
+
+        if not file_path:
+            return
+
+        try:
+            with open(file_path, 'r') as f:
+                data = json.load(f)
+
+            config = data.get("config", {})
+
+            self.vars["ssid"].set(config.get("ssid", ""))
+            self.vars["password"].set(config.get("password", ""))
+            self.vars["device_id"].set(config.get("device_id", ""))
+
+            wifi_power = config.get("wifi_power", "17dBm").replace("dBm", "")
+            self.vars["wifi_power"].set(wifi_power)
+
+            self.vars["o3_zero_value"].set(str(config.get("o3_zero_value", -1)))
+            self.vars["average_measurements"].set(str(config.get("average_measurements", 30)))
+            self.vars["sea_level_altitude"].set(str(config.get("sea_level_altitude", 122.00)))
+            self.vars["upload_server"].set(config.get("upload_server", ""))
+
+            mics_cal = config.get("mics_calibration_values", {})
+            self.vars["mics_cal_red"].set(str(mics_cal.get("RED", 955)))
+            self.vars["mics_cal_ox"].set(str(mics_cal.get("OX", 900)))
+            self.vars["mics_cal_nh3"].set(str(mics_cal.get("NH3", 163)))
+
+            mics_offset = config.get("mics_measurements_offsets", {})
+            self.vars["mics_offset_red"].set(str(mics_offset.get("RED", 0)))
+            self.vars["mics_offset_ox"].set(str(mics_offset.get("OX", 0)))
+            self.vars["mics_offset_nh3"].set(str(mics_offset.get("NH3", 0)))
+
+            comp = config.get("compensation_factors", {})
+            self.vars["comp_h"].set(str(comp.get("compH", 0.6)))
+            self.vars["comp_t"].set(str(comp.get("compT", 1.352)))
+            self.vars["comp_p"].set(str(comp.get("compP", 0.0132)))
+
+            self.vars["use_modem"].set(config.get("use_modem", False))
+            self.vars["modem_apn"].set(config.get("modem_apn", ""))
+
+            self.vars["ntp_server"].set(config.get("ntp_server", "pool.ntp.org"))
+            self.vars["timezone"].set(config.get("timezone", "GMT0"))
+
+            self.vars["fw_auto_upgrade"].set(config.get("fw_auto_upgrade", True))
+
+            gas_type_value = config.get("gas_sensor_type", 0)
+            gas_type_text = "MICS6814"
+            for text, value in GAS_SENSOR_TYPES.items():
+                if value == gas_type_value:
+                    gas_type_text = text
+                    break
+            self.vars["gas_sensor_type"].set(gas_type_text)
+
+            messagebox.showinfo("Success", "Configuration loaded successfully")
+        except Exception as e:
+            messagebox.showerror("Error", f"Failed to load configuration:\n{e}")
+
+    # ========================================================================
+    # ESP32 Flash Tab Methods
+    # ========================================================================
+
+    def log(self, message):
+        """Aggiunge un messaggio al log"""
+        self.log_text.config(state='normal')
+        self.log_text.insert(tk.END, message + "\n")
+        self.log_text.see(tk.END)
+        self.log_text.config(state='disabled')
+        self.root.update_idletasks()
+
+    def refresh_ports(self):
+        """Aggiorna la lista delle porte disponibili"""
+        ports = get_available_ports()
+
+        if not ports:
+            self.port_combo['values'] = ["Nessuna porta trovata"]
+            self.port_var.set("Nessuna porta trovata")
+            self.log("❌ Nessuna porta seriale trovata")
+        else:
+            port_descriptions = [f"{port} - {desc}" for port, desc in ports]
+            self.port_combo['values'] = port_descriptions
+            self.port_var.set(port_descriptions[0])
+            self.log(f"✅ Trovate {len(ports)} porte seriali")
+
+    def get_selected_port(self):
+        """Estrae il nome della porta dalla selezione"""
+        selection = self.port_var.get()
+        if " - " in selection:
+            return selection.split(" - ")[0]
+        return None
+
+    def detect_device(self):
+        """Rileva informazioni sul dispositivo ESP32"""
+        port = self.get_selected_port()
+        if not port:
+            messagebox.showwarning("Warning", "Seleziona una porta COM valida")
+            return
+
+        self.log(f"🔍 Rilevamento dispositivo su {port}...")
+
+        def detect_thread():
+            # Prima prova con il metodo standard
+            info = get_chip_info(port)
+
+            # Se il rilevamento ha dato risultati parziali o Unknown, prova il metodo verbose
+            if info and (info.get('chip') == 'Unknown' or info.get('flash_size') == 'Unknown'):
+                self.log("⚙️  Rilevamento standard incompleto, provo metodo alternativo...")
+                verbose_info = get_chip_info_verbose(port)
+
+                # Unisci le informazioni, preferendo quelle del metodo verbose se più complete
+                if verbose_info:
+                    if verbose_info.get('chip') != 'Unknown':
+                        info['chip'] = verbose_info['chip']
+                    if verbose_info.get('flash_size') != 'Unknown':
+                        info['flash_size'] = verbose_info['flash_size']
+                    if verbose_info.get('mac') != 'Unknown':
+                        info['mac'] = verbose_info['mac']
+
+                    # Log dell'output di debug se disponibile
+                    if 'debug_output' in verbose_info:
+                        self.log("📋 Output debug esptool:")
+                        for line in verbose_info['debug_output'].split('\n'):
+                            if line.strip() and any(keyword in line for keyword in
+                                ['Chip is', 'MAC:', 'Detected', 'Serial']):
+                                self.log(f"   {line.strip()}")
+
+            if info:
+                self.chip_info_text.config(state='normal')
+                self.chip_info_text.delete(1.0, tk.END)
+
+                chip_type = info.get('chip', 'Unknown')
+                mac_addr = info.get('mac', 'Unknown')
+                flash_size = info.get('flash_size', 'Unknown')
+
+                # Salva flash size rilevata (normalizza a 4MB o 8MB)
+                if '8' in flash_size.upper():
+                    self.detected_flash_size = "8MB"
+                elif '4' in flash_size.upper() or 'stimato' in flash_size.lower():
+                    self.detected_flash_size = "4MB"
+                else:
+                    self.detected_flash_size = "4MB"  # Default
+
+                self.log(f"💾 Flash size rilevata: {self.detected_flash_size}")
+
+                self.chip_info_text.insert(tk.END, f"Chip: {chip_type}\n")
+                self.chip_info_text.insert(tk.END, f"MAC: {mac_addr}\n")
+                self.chip_info_text.insert(tk.END, f"Flash Size: {flash_size}\n")
+
+                # Aggiungi nota se stimato
+                if 'stimato' in flash_size.lower() or 'default' in flash_size.lower():
+                    self.chip_info_text.insert(tk.END, "\nℹ️  Flash size stimata (4MB è il valore comune per ESP32)")
+
+                self.chip_info_text.config(state='disabled')
+
+                if chip_type != 'Unknown':
+                    self.log(f"✅ Dispositivo rilevato: {chip_type}")
+                else:
+                    self.log("⚠️  Dispositivo rilevato ma tipo sconosciuto")
+                    self.log("💡 Tip: Il flash funzionerà comunque con i parametri standard ESP32")
+            else:
+                self.log("❌ Impossibile rilevare il dispositivo")
+                self.log("💡 Verifica che:")
+                self.log("   - Il dispositivo sia collegato correttamente")
+                self.log("   - I driver USB siano installati (CH340/CP2102)")
+                self.log("   - Nessun altro programma stia usando la porta")
+                messagebox.showerror("Error",
+                    "Impossibile comunicare con il dispositivo.\n\n" +
+                    "Verifica connessione e driver USB.")
+
+        threading.Thread(target=detect_thread, daemon=True).start()
+
+    def download_latest_firmware(self):
+        """Scarica l'ultima release da GitHub"""
+        self.log(f"📥 Recupero info release da {GITHUB_REPO}...")
+
+        def download_thread():
+            self.release_info = get_latest_release_info(GITHUB_REPO)
+
+            if not self.release_info:
+                self.log("❌ Impossibile recuperare info release")
+                messagebox.showerror("Error", "Impossibile connettersi a GitHub")
+                return
+
+            version = get_release_version(self.release_info)
+            self.log(f"📦 Ultima versione disponibile: {version}")
+            self.log(f"💾 Scaricamento pacchetto per flash size: {self.detected_flash_size}")
+
+            # Download directory
+            download_dir = Path.home() / "Downloads" / "msp-firmware"
+
+            # Scarica il pacchetto completo (ZIP con tutti i file)
+            self.firmware_files = download_firmware_package(
+                self.release_info,
+                str(download_dir),
+                flash_size=self.detected_flash_size,
+                progress_callback=self.log
+            )
+
+            if self.firmware_files:
+                # Mostra info sul pacchetto scaricato
+                zip_name = Path(self.firmware_files['zip_path']).name if 'zip_path' in self.firmware_files else f"firmware-{self.detected_flash_size}"
+
+                self.firmware_label.config(
+                    text=f"✅ {zip_name} (v{version})",
+                    foreground="green"
+                )
+                self.flash_btn.config(state='normal')
+
+                self.log(f"✅ Pacchetto firmware scaricato ed estratto:")
+                self.log(f"   • Bootloader: {Path(self.firmware_files['bootloader']).name}")
+                self.log(f"   • Partitions: {Path(self.firmware_files['partitions']).name}")
+                self.log(f"   • Boot App0: {Path(self.firmware_files['boot_app0']).name}")
+                self.log(f"   • Firmware: {Path(self.firmware_files['firmware']).name}")
+
+                # Mantieni compatibilità backward per firmware_path
+                self.firmware_path = self.firmware_files['firmware']
+            else:
+                self.log("❌ Errore durante il download del pacchetto firmware")
+                messagebox.showerror("Error", "Impossibile scaricare il firmware da GitHub")
+
+        threading.Thread(target=download_thread, daemon=True).start()
+
+    def select_local_firmware(self):
+        """Seleziona un file firmware locale (.zip o .bin)"""
+        file_path = filedialog.askopenfilename(
+            title="Seleziona file firmware (.zip consigliato, .bin solo per update)",
+            filetypes=[
+                ("ZIP files", "*.zip"),
+                ("Binary files", "*.bin"),
+                ("All files", "*.*")
+            ]
+        )
+
+        if file_path:
+            if file_path.endswith('.zip'):
+                # Estrai il ZIP e trova i file
+                import zipfile
+                import tempfile
+
+                try:
+                    extract_dir = tempfile.mkdtemp(prefix="msp_firmware_")
+                    with zipfile.ZipFile(file_path, 'r') as zip_ref:
+                        zip_ref.extractall(extract_dir)
+
+                    # Trova i file necessari
+                    self.firmware_files = {
+                        'bootloader': None,
+                        'partitions': None,
+                        'boot_app0': None,
+                        'firmware': None,
+                        'zip_path': file_path,
+                        'extract_dir': extract_dir
+                    }
+
+                    for root, dirs, files in os.walk(extract_dir):
+                        for file in files:
+                            filepath = os.path.join(root, file)
+                            if 'bootloader' in file and file.endswith('.bin'):
+                                self.firmware_files['bootloader'] = filepath
+                            elif 'partitions' in file and file.endswith('.bin'):
+                                self.firmware_files['partitions'] = filepath
+                            elif 'boot_app0' in file and file.endswith('.bin'):
+                                self.firmware_files['boot_app0'] = filepath
+                            elif file == 'msp-firmware.ino.bin':
+                                self.firmware_files['firmware'] = filepath
+
+                    # Verifica che tutti i file siano stati trovati
+                    missing = [k for k, v in self.firmware_files.items() if v is None and k not in ['zip_path', 'extract_dir']]
+                    if missing:
+                        self.log(f"⚠️  File mancanti nello ZIP: {missing}")
+                        messagebox.showwarning("Warning", f"ZIP incompleto. File mancanti: {missing}")
+                        return
+
+                    self.firmware_path = self.firmware_files['firmware']  # Compatibilità
+                    self.firmware_label.config(
+                        text=f"✅ {Path(file_path).name} (pacchetto completo)",
+                        foreground="green"
+                    )
+                    self.flash_btn.config(state='normal')
+                    self.log(f"✅ Pacchetto firmware selezionato: {Path(file_path).name}")
+                    self.log("   ✓ Bootloader, partitions, boot_app0 e firmware trovati")
+
+                except Exception as e:
+                    self.log(f"❌ Errore estrazione ZIP: {e}")
+                    messagebox.showerror("Error", f"Impossibile estrarre il file ZIP:\n{e}")
+
+            else:
+                # File .bin singolo (solo update, non flash completo)
+                self.firmware_path = file_path
+                self.firmware_files = None  # Nessun pacchetto completo
+                self.firmware_label.config(
+                    text=f"⚠️  {Path(file_path).name} (solo update, no bootloader)",
+                    foreground="orange"
+                )
+                self.flash_btn.config(state='normal')
+                self.log(f"⚠️  File .bin singolo selezionato: {file_path}")
+                self.log("⚠️  ATTENZIONE: Un file .bin singolo NON include bootloader!")
+                self.log("💡 Usa un file .zip per un flash completo dopo erase")
+                messagebox.showwarning(
+                    "Attenzione",
+                    "Hai selezionato un file .bin singolo.\n\n" +
+                    "Questo è adatto solo per UPDATE OTA, non per flash completo.\n\n" +
+                    "Se hai fatto 'Erase Flash', scarica il pacchetto .zip completo da GitHub!"
+                )
+
+    def flash_device(self):
+        """Flasha il firmware sul dispositivo"""
+        port = self.get_selected_port()
+        if not port:
+            messagebox.showwarning("Warning", "Seleziona una porta COM valida")
+            return
+
+        if not self.firmware_path and not self.firmware_files:
+            messagebox.showwarning("Warning", "Seleziona prima un firmware")
+            return
+
+        # Determina se abbiamo un pacchetto completo o solo un .bin
+        has_full_package = self.firmware_files is not None
+
+        if has_full_package:
+            confirm_msg = (
+                f"Flashare il firmware completo su {port}?\n\n" +
+                f"Questo installerà:\n" +
+                f"  • Bootloader (0x1000)\n" +
+                f"  • Partition Table (0x8000)\n" +
+                f"  • Boot App0 (0xe000)\n" +
+                f"  • Firmware principale (0x10000)\n\n" +
+                f"Flash size: {self.detected_flash_size}"
+            )
+        else:
+            confirm_msg = (
+                f"⚠️ ATTENZIONE: Stai flashando solo il file .bin!\n\n" +
+                f"Questo NON include bootloader e partition table.\n" +
+                f"È adatto solo per update OTA, non dopo erase_flash.\n\n" +
+                f"Vuoi continuare comunque?"
+            )
+
+        result = messagebox.askyesno("Conferma Flash", confirm_msg)
+
+        if not result:
+            return
+
+        self.log(f"⚡ Inizio flash su {port}...")
+        self.log(f"💾 Flash size: {self.detected_flash_size}")
+        self.flash_btn.config(state='disabled')
+
+        def flash_thread():
+            if has_full_package:
+                # Flash pacchetto completo (raccomandato)
+                self.log("📦 Flash pacchetto completo (bootloader + firmware)...")
+                success, message = flash_firmware_package(
+                    port,
+                    self.firmware_files,
+                    flash_size=self.detected_flash_size,
+                    progress_callback=self.log
+                )
+            else:
+                # Flash solo firmware (deprecato, solo per update)
+                self.log("⚠️  Flash solo firmware (nessun bootloader)...")
+                success, message = flash_firmware(
+                    port,
+                    self.firmware_path,
+                    flash_size=self.detected_flash_size,
+                    progress_callback=self.log
+                )
+
+            if success:
+                self.log(f"✅ {message}")
+                messagebox.showinfo("Success", message)
+            else:
+                self.log(f"❌ {message}")
+                messagebox.showerror("Error", message)
+
+            self.flash_btn.config(state='normal')
+
+        threading.Thread(target=flash_thread, daemon=True).start()
+
+    def erase_device_flash(self):
+        """Cancella la flash del dispositivo"""
+        port = self.get_selected_port()
+        if not port:
+            messagebox.showwarning("Warning", "Seleziona una porta COM valida")
+            return
+
+        result = messagebox.askyesno(
+            "Conferma",
+            f"Cancellare completamente la flash su {port}?\n\n⚠️ Questa operazione è IRREVERSIBILE!"
+        )
+
+        if not result:
+            return
+
+        self.log(f"🗑️ Cancellazione flash su {port}...")
+
+        def erase_thread():
+            success, message = erase_flash(port, progress_callback=self.log)
+
+            if success:
+                self.log(f"✅ {message}")
+                messagebox.showinfo("Success", message)
+            else:
+                self.log(f"❌ {message}")
+                messagebox.showerror("Error", message)
+
+        threading.Thread(target=erase_thread, daemon=True).start()
+
+
+def main():
+    root = tk.Tk()
+    app = ConfigGeneratorGUI(root)
+    root.mainloop()
+
+
+if __name__ == "__main__":
+    main()

--- a/config_generator/esp32_utils.py
+++ b/config_generator/esp32_utils.py
@@ -1,0 +1,434 @@
+"""
+ESP32 utilities module
+Funzioni per interagire con ESP32: rilevamento porte, flash size, flashing
+"""
+
+import serial.tools.list_ports
+import subprocess
+import sys
+import os
+from typing import List, Tuple, Optional
+
+
+def get_available_ports() -> List[Tuple[str, str]]:
+    """
+    Ottiene la lista delle porte seriali disponibili
+
+    Returns:
+        Lista di tuple (porta, descrizione)
+    """
+    ports = serial.tools.list_ports.comports()
+    available_ports = []
+
+    for port in ports:
+        # Filtra porte che potrebbero essere ESP32
+        description = f"{port.device} - {port.description}"
+        if port.manufacturer:
+            description += f" ({port.manufacturer})"
+        available_ports.append((port.device, description))
+
+    return available_ports
+
+
+def get_chip_info_verbose(port: str) -> Optional[dict]:
+    """
+    Ottiene informazioni sul chip con metodo più verboso per debugging
+
+    Args:
+        port: Porta seriale del dispositivo
+
+    Returns:
+        Dizionario con informazioni e output completo
+    """
+    try:
+        # Prova prima con read_mac per connessione di base
+        result = subprocess.run(
+            [sys.executable, "-m", "esptool", "--port", port, "read_mac"],
+            capture_output=True,
+            text=True,
+            timeout=30
+        )
+
+        full_output = result.stdout + "\n" + result.stderr
+        info = {
+            'chip': 'ESP32 (generico)',
+            'mac': 'Unknown',
+            'flash_size': '4MB (stimato)',
+            'debug_output': full_output
+        }
+
+        # Estrai MAC address
+        for line in full_output.split('\n'):
+            if 'MAC:' in line:
+                mac = line.split('MAC:')[-1].strip()
+                info['mac'] = mac
+            elif 'Chip is' in line:
+                chip_type = line.split('Chip is')[-1].strip().split('(')[0].strip()
+                info['chip'] = chip_type
+
+        # Ora prova flash_id per dimensione flash
+        result2 = subprocess.run(
+            [sys.executable, "-m", "esptool", "--port", port, "flash_id"],
+            capture_output=True,
+            text=True,
+            timeout=30
+        )
+
+        flash_output = result2.stdout + "\n" + result2.stderr
+        info['debug_output'] += "\n\n--- FLASH_ID ---\n" + flash_output
+
+        for line in flash_output.split('\n'):
+            if 'Detected flash size:' in line:
+                flash_size = line.split(':')[-1].strip()
+                info['flash_size'] = flash_size
+            elif 'Chip is' in line and info['chip'] == 'ESP32 (generico)':
+                chip_type = line.split('Chip is')[-1].strip().split('(')[0].strip()
+                info['chip'] = chip_type
+
+        return info
+
+    except Exception as e:
+        return {
+            'chip': 'ESP32 (non rilevato)',
+            'mac': 'Unknown',
+            'flash_size': '4MB (default)',
+            'error': str(e)
+        }
+
+
+def detect_flash_size(port: str) -> Optional[str]:
+    """
+    Rileva automaticamente la dimensione della flash dell'ESP32
+
+    Args:
+        port: Porta seriale del dispositivo
+
+    Returns:
+        Dimensione della flash (es: "4MB") o None se non rilevata
+    """
+    try:
+        # Usa esptool per leggere le informazioni del chip
+        result = subprocess.run(
+            [sys.executable, "-m", "esptool", "--port", port, "flash_id"],
+            capture_output=True,
+            text=True,
+            timeout=30
+        )
+
+        if result.returncode != 0:
+            return None
+
+        # Parse dell'output per trovare la dimensione della flash
+        output = result.stdout
+        for line in output.split('\n'):
+            if 'Detected flash size:' in line:
+                # Estrai la dimensione (es: "4MB")
+                size = line.split(':')[-1].strip()
+                return size
+
+        return None
+    except Exception as e:
+        print(f"Errore nel rilevamento della flash size: {e}")
+        return None
+
+
+def get_chip_info(port: str) -> Optional[dict]:
+    """
+    Ottiene informazioni dettagliate sul chip ESP32
+
+    Args:
+        port: Porta seriale del dispositivo
+
+    Returns:
+        Dizionario con informazioni sul chip o None
+    """
+    try:
+        # Usa flash_id che fornisce più informazioni
+        result = subprocess.run(
+            [sys.executable, "-m", "esptool", "--port", port, "flash_id"],
+            capture_output=True,
+            text=True,
+            timeout=30
+        )
+
+        if result.returncode != 0:
+            return None
+
+        output = result.stdout + "\n" + result.stderr
+        info = {
+            'chip': 'Unknown',
+            'mac': 'Unknown',
+            'flash_size': 'Unknown'
+        }
+
+        # Parse output per trovare informazioni
+        for line in output.split('\n'):
+            # Rileva tipo di chip
+            if 'Chip is' in line:
+                chip_type = line.split('Chip is')[-1].strip()
+                # Rimuovi parentesi e info extra
+                chip_type = chip_type.split('(')[0].strip()
+                info['chip'] = chip_type
+
+            # Rileva MAC address
+            elif 'MAC:' in line:
+                mac = line.split('MAC:')[-1].strip()
+                info['mac'] = mac
+
+            # Rileva flash size
+            elif 'Detected flash size:' in line:
+                flash_size = line.split(':')[-1].strip()
+                info['flash_size'] = flash_size
+
+            # Alternativa per il rilevamento del chip
+            elif 'Detecting chip type' in line:
+                if 'ESP32' in line:
+                    info['chip'] = 'ESP32'
+
+            # Rileva chip type dall'header
+            elif 'Serial port' in line:
+                # Continua a cercare nelle righe successive
+                pass
+
+        # Se non abbiamo trovato il chip, prova a indovinare dalla presenza di ESP32
+        if info['chip'] == 'Unknown' and 'esp32' in output.lower():
+            info['chip'] = 'ESP32'
+
+        # Se non abbiamo la flash size, usa un default
+        if info['flash_size'] == 'Unknown':
+            # Prova a cercare nell'output per indizi
+            if '4MB' in output or '4 MB' in output:
+                info['flash_size'] = '4MB'
+            elif '2MB' in output or '2 MB' in output:
+                info['flash_size'] = '2MB'
+            elif '8MB' in output or '8 MB' in output:
+                info['flash_size'] = '8MB'
+            else:
+                info['flash_size'] = '4MB (stimato)'
+
+        return info
+    except Exception as e:
+        print(f"Errore nel recupero info chip: {e}")
+        return None
+
+
+def flash_firmware_package(port: str, firmware_files: dict, flash_size: str = "4MB",
+                          baudrate: int = 921600, progress_callback=None) -> Tuple[bool, str]:
+    """
+    Flasha il pacchetto firmware completo sull'ESP32 (bootloader + partitions + app)
+
+    Args:
+        port: Porta seriale del dispositivo
+        firmware_files: Dizionario con paths dei file del firmware:
+            {
+                'bootloader': path_bootloader,
+                'partitions': path_partitions,
+                'boot_app0': path_boot_app0,
+                'firmware': path_firmware
+            }
+        flash_size: Dimensione della flash (es: "4MB")
+        baudrate: Velocità di comunicazione
+        progress_callback: Funzione callback per gli aggiornamenti di progresso
+
+    Returns:
+        Tuple (success: bool, message: str)
+    """
+    try:
+        # Verifica che tutti i file esistano
+        required_files = ['bootloader', 'partitions', 'boot_app0', 'firmware']
+        for file_key in required_files:
+            if file_key not in firmware_files or not firmware_files[file_key]:
+                return False, f"File mancante: {file_key}"
+            if not os.path.exists(firmware_files[file_key]):
+                return False, f"File non trovato: {firmware_files[file_key]}"
+
+        # Indirizzi di flash per ESP32
+        flash_addresses = {
+            'bootloader': '0x1000',
+            'partitions': '0x8000',
+            'boot_app0': '0xe000',
+            'firmware': '0x10000'
+        }
+
+        # Comando esptool per il flash completo
+        cmd = [
+            sys.executable, "-m", "esptool",
+            "--port", port,
+            "--baud", str(baudrate),
+            "--before", "default_reset",
+            "--after", "hard_reset",
+            "write_flash",
+            "-z",
+            "--flash_mode", "dio",
+            "--flash_freq", "80m",
+            "--flash_size", flash_size
+        ]
+
+        # Aggiungi ogni file con il suo indirizzo
+        for file_key in required_files:
+            cmd.append(flash_addresses[file_key])
+            cmd.append(firmware_files[file_key])
+
+        if progress_callback:
+            progress_callback("Connessione all'ESP32...")
+            progress_callback(f"Flash size: {flash_size}")
+            progress_callback("Scrittura: bootloader + partitions + boot_app0 + firmware")
+
+        # Esegui il flash
+        process = subprocess.Popen(
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            bufsize=1
+        )
+
+        output_lines = []
+        for line in iter(process.stdout.readline, ''):
+            if line:
+                output_lines.append(line.strip())
+                if progress_callback:
+                    # Estrai la percentuale se presente
+                    if '%' in line:
+                        progress_callback(line.strip())
+                    elif 'Connecting' in line:
+                        progress_callback("Connessione in corso...")
+                    elif 'Writing at' in line:
+                        # Estrai l'indirizzo corrente
+                        if '0x00001000' in line or 'bootloader' in line.lower():
+                            progress_callback("Scrittura bootloader...")
+                        elif '0x00008000' in line:
+                            progress_callback("Scrittura partition table...")
+                        elif '0x0000e000' in line:
+                            progress_callback("Scrittura boot_app0...")
+                        elif '0x00010000' in line:
+                            progress_callback("Scrittura firmware principale...")
+                        else:
+                            progress_callback("Scrittura firmware...")
+                    elif 'Hash' in line:
+                        progress_callback("Verifica hash...")
+                    elif 'Leaving' in line:
+                        progress_callback("Riavvio dispositivo...")
+
+        process.wait()
+
+        if process.returncode == 0:
+            return True, "Flash completato con successo! Bootloader, partitions e firmware installati."
+        else:
+            error_msg = "\n".join(output_lines[-10:])  # Ultime 10 righe
+            return False, f"Errore durante il flash:\n{error_msg}"
+
+    except subprocess.TimeoutExpired:
+        return False, "Timeout durante il flash. Riprova."
+    except Exception as e:
+        return False, f"Errore durante il flash: {str(e)}"
+
+
+def flash_firmware(port: str, firmware_path: str, flash_size: str = "4MB",
+                  baudrate: int = 921600, progress_callback=None) -> Tuple[bool, str]:
+    """
+    DEPRECATED: Usa flash_firmware_package per un flash completo con bootloader
+
+    Flasha solo il firmware principale sull'ESP32 (solo app, senza bootloader)
+    Questa funzione è mantenuta per compatibilità ma NON dovrebbe essere usata
+    per un flash completo dopo erase_flash.
+
+    Args:
+        port: Porta seriale del dispositivo
+        firmware_path: Path del file .bin del firmware
+        flash_size: Dimensione della flash (es: "4MB")
+        baudrate: Velocità di comunicazione
+        progress_callback: Funzione callback per gli aggiornamenti di progresso
+
+    Returns:
+        Tuple (success: bool, message: str)
+    """
+    try:
+        if not os.path.exists(firmware_path):
+            return False, f"File firmware non trovato: {firmware_path}"
+
+        # Comando esptool per il flash
+        cmd = [
+            sys.executable, "-m", "esptool",
+            "--port", port,
+            "--baud", str(baudrate),
+            "--before", "default_reset",
+            "--after", "hard_reset",
+            "write_flash",
+            "-z",
+            "--flash_mode", "dio",
+            "--flash_freq", "40m",
+            "--flash_size", flash_size,
+            "0x10000", firmware_path  # Indirizzo standard per l'app ESP32
+        ]
+
+        if progress_callback:
+            progress_callback("Connessione all'ESP32...")
+
+        # Esegui il flash
+        process = subprocess.Popen(
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            bufsize=1
+        )
+
+        output_lines = []
+        for line in iter(process.stdout.readline, ''):
+            if line:
+                output_lines.append(line.strip())
+                if progress_callback:
+                    # Estrai la percentuale se presente
+                    if '%' in line:
+                        progress_callback(line.strip())
+                    elif 'Connecting' in line:
+                        progress_callback("Connessione in corso...")
+                    elif 'Writing' in line:
+                        progress_callback("Scrittura firmware...")
+                    elif 'Hash' in line:
+                        progress_callback("Verifica hash...")
+
+        process.wait()
+
+        if process.returncode == 0:
+            return True, "Flash completato con successo!"
+        else:
+            error_msg = "\n".join(output_lines[-10:])  # Ultime 10 righe
+            return False, f"Errore durante il flash:\n{error_msg}"
+
+    except subprocess.TimeoutExpired:
+        return False, "Timeout durante il flash. Riprova."
+    except Exception as e:
+        return False, f"Errore durante il flash: {str(e)}"
+
+
+def erase_flash(port: str, progress_callback=None) -> Tuple[bool, str]:
+    """
+    Cancella completamente la flash dell'ESP32
+
+    Args:
+        port: Porta seriale del dispositivo
+        progress_callback: Funzione callback per gli aggiornamenti
+
+    Returns:
+        Tuple (success: bool, message: str)
+    """
+    try:
+        if progress_callback:
+            progress_callback("Cancellazione flash in corso...")
+
+        result = subprocess.run(
+            [sys.executable, "-m", "esptool", "--port", port, "erase_flash"],
+            capture_output=True,
+            text=True,
+            timeout=60
+        )
+
+        if result.returncode == 0:
+            return True, "Flash cancellata con successo"
+        else:
+            return False, f"Errore durante la cancellazione: {result.stderr}"
+
+    except Exception as e:
+        return False, f"Errore: {str(e)}"

--- a/config_generator/github_utils.py
+++ b/config_generator/github_utils.py
@@ -1,0 +1,240 @@
+"""
+GitHub utilities module
+Funzioni per interagire con GitHub releases
+"""
+
+import requests
+import os
+import zipfile
+import platform
+from typing import Optional, Tuple, Dict
+from pathlib import Path
+
+
+def get_latest_release_info(repo: str) -> Optional[dict]:
+    """
+    Ottiene informazioni sull'ultima release da GitHub
+
+    Args:
+        repo: Nome del repository nel formato "owner/repo"
+
+    Returns:
+        Dizionario con info sulla release o None
+    """
+    try:
+        api_url = f"https://api.github.com/repos/{repo}/releases/latest"
+        response = requests.get(api_url, timeout=10)
+
+        if response.status_code == 200:
+            return response.json()
+        else:
+            print(f"Errore API GitHub: {response.status_code}")
+            return None
+
+    except Exception as e:
+        print(f"Errore nel recupero info release: {e}")
+        return None
+
+
+def download_firmware_package(release_info: dict, download_dir: str,
+                             flash_size: str = "4MB",
+                             progress_callback=None) -> Optional[dict]:
+    """
+    Scarica il pacchetto firmware completo (.zip) dalla release
+
+    Args:
+        release_info: Dizionario con info sulla release
+        download_dir: Directory dove salvare il file
+        flash_size: Dimensione flash ("4MB" o "8MB")
+        progress_callback: Funzione callback per il progresso
+
+    Returns:
+        Dizionario con paths dei file estratti o None
+    """
+    try:
+        assets = release_info.get('assets', [])
+
+        # Determina quale ZIP scaricare basato su flash size e OS
+        system = platform.system().lower()
+        if system == "darwin":
+            platform_suffix = "macos"
+        elif system == "windows":
+            platform_suffix = "win64"
+        else:  # Linux
+            platform_suffix = "macos"  # Usa macOS per Linux (compatibile)
+
+        # Normalizza flash size
+        flash_size_str = flash_size.upper().replace("MB", "MB").replace(" ", "")
+        if "4" in flash_size_str:
+            flash_size_str = "4MB"
+        elif "8" in flash_size_str:
+            flash_size_str = "8MB"
+        else:
+            flash_size_str = "4MB"  # Default
+
+        # Cerca il file ZIP appropriato
+        zip_asset = None
+        version = get_release_version(release_info)
+
+        # Cerca pattern: msp-firmware-FLASH{size}-v{version}-{platform}.zip
+        search_pattern = f"FLASH{flash_size_str}"
+
+        for asset in assets:
+            filename = asset['name']
+            if filename.endswith('.zip') and search_pattern in filename and platform_suffix in filename:
+                zip_asset = asset
+                break
+
+        if not zip_asset:
+            # Fallback: prova a cercare qualsiasi ZIP con la flash size corretta
+            for asset in assets:
+                filename = asset['name']
+                if filename.endswith('.zip') and search_pattern in filename:
+                    zip_asset = asset
+                    break
+
+        if not zip_asset:
+            print(f"Nessun file ZIP trovato per {flash_size_str}")
+            return None
+
+        download_url = zip_asset['browser_download_url']
+        filename = zip_asset['name']
+        file_size = zip_asset['size']
+
+        # Path completo del file
+        os.makedirs(download_dir, exist_ok=True)
+        zip_filepath = os.path.join(download_dir, filename)
+
+        if progress_callback:
+            progress_callback(f"Download di {filename}...")
+
+        # Download con barra di progresso
+        response = requests.get(download_url, stream=True, timeout=30)
+
+        if response.status_code != 200:
+            return None
+
+        downloaded = 0
+        chunk_size = 8192
+
+        with open(zip_filepath, 'wb') as f:
+            for chunk in response.iter_content(chunk_size=chunk_size):
+                if chunk:
+                    f.write(chunk)
+                    downloaded += len(chunk)
+
+                    if progress_callback and file_size > 0:
+                        percentage = (downloaded / file_size) * 100
+                        progress_callback(f"Download: {percentage:.1f}%")
+
+        if progress_callback:
+            progress_callback(f"Estrazione dei file...")
+
+        # Estrai il ZIP
+        extract_dir = os.path.join(download_dir, f"firmware_{version}_{flash_size_str}")
+        os.makedirs(extract_dir, exist_ok=True)
+
+        with zipfile.ZipFile(zip_filepath, 'r') as zip_ref:
+            zip_ref.extractall(extract_dir)
+
+        if progress_callback:
+            progress_callback(f"Estrazione completata!")
+
+        # Trova i file necessari nel directory estratto
+        firmware_files = {
+            'bootloader': None,
+            'partitions': None,
+            'boot_app0': None,
+            'firmware': None,
+            'zip_path': zip_filepath,
+            'extract_dir': extract_dir
+        }
+
+        for root, dirs, files in os.walk(extract_dir):
+            for file in files:
+                filepath = os.path.join(root, file)
+                if 'bootloader' in file and file.endswith('.bin'):
+                    firmware_files['bootloader'] = filepath
+                elif 'partitions' in file and file.endswith('.bin'):
+                    firmware_files['partitions'] = filepath
+                elif 'boot_app0' in file and file.endswith('.bin'):
+                    firmware_files['boot_app0'] = filepath
+                elif file == 'msp-firmware.ino.bin':
+                    firmware_files['firmware'] = filepath
+
+        # Verifica che tutti i file siano stati trovati
+        missing = [k for k, v in firmware_files.items() if v is None and k not in ['zip_path', 'extract_dir']]
+        if missing:
+            print(f"File mancanti nell'archivio: {missing}")
+            return None
+
+        return firmware_files
+
+    except Exception as e:
+        print(f"Errore nel download/estrazione: {e}")
+        return None
+
+
+# Mantieni la funzione legacy per compatibilità
+def download_firmware_asset(release_info: dict, download_dir: str,
+                           progress_callback=None) -> Optional[str]:
+    """
+    DEPRECATED: Usa download_firmware_package invece
+
+    Questa funzione scarica solo il .bin ed è mantenuta per compatibilità.
+    Per un flash completo usa download_firmware_package che scarica tutto il pacchetto.
+    """
+    package = download_firmware_package(release_info, download_dir, "4MB", progress_callback)
+    if package:
+        return package.get('firmware')
+    return None
+
+
+def get_release_version(release_info: dict) -> str:
+    """
+    Estrae la versione dalla release
+
+    Args:
+        release_info: Dizionario con info sulla release
+
+    Returns:
+        Stringa con la versione
+    """
+    return release_info.get('tag_name', 'Unknown')
+
+
+def get_release_notes(release_info: dict) -> str:
+    """
+    Estrae le note di rilascio
+
+    Args:
+        release_info: Dizionario con info sulla release
+
+    Returns:
+        Stringa con le note di rilascio
+    """
+    return release_info.get('body', 'Nessuna descrizione disponibile')
+
+
+def check_for_updates(repo: str, current_version: Optional[str] = None) -> Tuple[bool, Optional[dict]]:
+    """
+    Controlla se c'è una nuova versione disponibile
+
+    Args:
+        repo: Nome del repository
+        current_version: Versione corrente (opzionale)
+
+    Returns:
+        Tuple (has_update: bool, release_info: dict)
+    """
+    release_info = get_latest_release_info(repo)
+
+    if not release_info:
+        return False, None
+
+    if current_version:
+        latest_version = get_release_version(release_info)
+        has_update = latest_version != current_version
+        return has_update, release_info
+    else:
+        return True, release_info

--- a/config_generator/requirements.txt
+++ b/config_generator/requirements.txt
@@ -1,0 +1,10 @@
+# MSP Firmware Config Generator Requirements
+
+# Per la comunicazione seriale con ESP32
+pyserial>=3.5
+
+# Per il flash dell'ESP32
+esptool>=4.7
+
+# Per scaricare le release da GitHub
+requests>=2.31.0

--- a/config_generator/run_gui.bat
+++ b/config_generator/run_gui.bat
@@ -1,0 +1,48 @@
+@echo off
+REM Script di avvio per la GUI Config Generator (Windows)
+
+cd /d "%~dp0"
+
+REM Controlla se esiste l'ambiente virtuale
+if not exist "venv\" (
+    echo Ambiente virtuale non trovato. Creazione in corso...
+    python -m venv venv
+
+    if errorlevel 1 (
+        echo Errore: impossibile creare l'ambiente virtuale
+        echo Assicurati di avere Python 3 installato: python --version
+        pause
+        exit /b 1
+    )
+
+    echo Ambiente virtuale creato con successo!
+)
+
+REM Attiva l'ambiente virtuale
+call venv\Scripts\activate.bat
+
+if errorlevel 1 (
+    echo Errore: impossibile attivare l'ambiente virtuale
+    pause
+    exit /b 1
+)
+
+REM Installa/aggiorna le dipendenze
+echo Controllo dipendenze...
+python -m pip install -q --upgrade pip
+pip install -q -r requirements.txt
+
+if errorlevel 1 (
+    echo Errore: impossibile installare le dipendenze
+    pause
+    exit /b 1
+)
+
+REM Avvia la GUI
+echo Avvio Config Generator GUI...
+python config_generator_gui.py
+
+REM Disattiva l'ambiente virtuale
+deactivate
+
+pause

--- a/config_generator/run_gui.sh
+++ b/config_generator/run_gui.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# Script di avvio per la GUI Config Generator (macOS/Linux)
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+cd "$SCRIPT_DIR"
+
+# Controlla se esiste l'ambiente virtuale
+if [ ! -d "venv" ]; then
+    echo "Ambiente virtuale non trovato. Creazione in corso..."
+    python3 -m venv venv
+
+    if [ $? -ne 0 ]; then
+        echo "Errore: impossibile creare l'ambiente virtuale"
+        echo "Assicurati di avere Python 3 installato: python3 --version"
+        exit 1
+    fi
+
+    echo "Ambiente virtuale creato con successo!"
+fi
+
+# Attiva l'ambiente virtuale
+source venv/bin/activate
+
+if [ $? -ne 0 ]; then
+    echo "Errore: impossibile attivare l'ambiente virtuale"
+    exit 1
+fi
+
+# Installa/aggiorna le dipendenze
+echo "Controllo dipendenze..."
+pip install -q --upgrade pip
+pip install -q -r requirements.txt
+
+if [ $? -ne 0 ]; then
+    echo "Errore: impossibile installare le dipendenze"
+    exit 1
+fi
+
+# Avvia la GUI
+echo "Avvio Config Generator GUI..."
+python config_generator_gui.py
+
+# Disattiva l'ambiente virtuale
+deactivate

--- a/display.cpp
+++ b/display.cpp
@@ -374,7 +374,7 @@ void vHalDisplay_drawMICSxx14PollutionSensorData(sensorData_t *p_tData, systemSt
   char sensorStringData[SENSOR_DATA_STR_FMT_LEN] = {0};
 
   vHal_displayDrawScrHead(statPtr, devinfoPtr);
-  if (p_tData->status.MICS6814Sensor)
+  if ((p_tData->status.MICS6814Sensor) || (p_tData->status.MICS4514Sensor))
   {
     vGeneric_dspFloatToComma(p_tData->pollutionData.carbonMonoxide, sensorStringData, sizeof(sensorStringData));
     u8g2.setCursor(MEAS_DISP_X_OFFSET, MEAS_DISP_Y_OFFSET_L1);
@@ -631,10 +631,7 @@ void vMsp_updateDataAndSendEvent(displayEvents_t event,
 
   vMspOs_takeDataAccessMutex();
 
-  if (event == DISP_EVENT_SHOW_MEAS_DATA)
-  {
-    localDisplayData.sensorData = *sensorData;
-  }
+  localDisplayData.sensorData = *sensorData; // Always copy so fallback SHOW_MEAS_DATA has valid status flags
   localDisplayData.devInfo = *devInfo;
   localDisplayData.measStat = *measStat;
   localDisplayData.sysData = *sysData;

--- a/msp-firmware.ino
+++ b/msp-firmware.ino
@@ -454,8 +454,7 @@ void setup()
   measStat.curr_minutes = 0;
   measStat.curr_seconds = 0;
   measStat.curr_total_seconds = 0;
-  measStat.last_transmission_minute = -1; // Initialize to invalid minute
-  measStat.last_transmission_hour = -1;   // Initialize to invalid hour
+  measStat.last_transmission_epoch = 0; // 0 = never transmitted
 
   // STEP 4: Request network connection and wait for NTP sync
   log_i("=== STEP 4: Requesting network connection and NTP sync ===");
@@ -1273,80 +1272,53 @@ void loop()
     }
 
     // Check if it's time to send data
-    // We transmit when: 1) we're at a transmission boundary AND 2) haven't transmitted at this boundary yet
+    // We transmit when:
+    //   1) At a clock-aligned interval boundary (curr_minutes % max_measurements == 0)
+    //      OR enough seconds have elapsed since the last transmission (fallback for missed windows)
+    //   2) Enough measurements have been collected for this cycle
+    //   3) Haven't already transmitted in this boundary window
 
-    // Improved boundary logic: check if current minute is at interval boundary OR enough time has passed since last transmission
-    // IMPORTANT: Use max_measurements (configured interval) NOT avg_measurements (dynamic cycle count)
-    bool at_transmission_boundary = ((measStat.curr_minutes % measStat.max_measurements) == 0); // Standard interval boundary
+    time_t now_epoch = mktime(&timeinfo);
 
-    // Alternative boundary check: if enough time has passed since last transmission (handles hour rollover)
-    bool enough_time_passed = false;
-    if (measStat.last_transmission_minute >= 0) // Only check if we have a previous transmission
-    {
-      int minutes_since_last_tx = 0;
-      if (measStat.curr_minutes > measStat.last_transmission_minute)
-      {
-        // Same hour, minutes increased
-        minutes_since_last_tx = measStat.curr_minutes - measStat.last_transmission_minute;
-      }
-      else if (measStat.curr_minutes < measStat.last_transmission_minute)
-      {
-        // Hour rollover (e.g., from minute 58 to minute 2)
-        minutes_since_last_tx = (60 - measStat.last_transmission_minute) + measStat.curr_minutes;
-      }
-      else
-      {
-        // Same minute as last transmission (curr_minutes == last_transmission_minute)
-        // NEVER allow retransmission at the same minute - this prevents duplicates
-        minutes_since_last_tx = 0;
-      }
-      enough_time_passed = (minutes_since_last_tx >= measStat.max_measurements);
-    }
-    else
-    {
-      // First transmission ever - wait for standard boundary
-      // Do NOT automatically allow transmission on first boot
-      enough_time_passed = false;
-    }
+    // Compute seconds elapsed since last transmission (0 if never transmitted)
+    int32_t seconds_since_last_tx = (measStat.last_transmission_epoch > 0)
+                                    ? (int32_t)(now_epoch - measStat.last_transmission_epoch)
+                                    : 0;
 
-    // Use either standard boundary OR enough time has passed
+    int32_t interval_seconds = (int32_t)(measStat.max_measurements * SEC_IN_MIN);
+
+    // Standard clock-aligned boundary (e.g. minute 0 for hourly, minute 0/30 for 30-min)
+    bool at_transmission_boundary = ((measStat.curr_minutes % measStat.max_measurements) == 0);
+
+    // Fallback: enough seconds have elapsed regardless of minute alignment.
+    // This handles all rollover cases (including 60-min: same minute across hours) and
+    // recovers gracefully if the exact boundary second is missed due to processing delays.
+    bool enough_time_passed = (measStat.last_transmission_epoch > 0) &&
+                              (seconds_since_last_tx >= interval_seconds);
+
     at_transmission_boundary = at_transmission_boundary || enough_time_passed;
 
-    // Prevent duplicate transmissions at same boundary
-    // STRICT: Only transmit once per boundary - check both hour and minute
-    // Get current hour for comparison
+    // Duplicate guard: only transmit once per boundary window.
+    // "Not yet transmitted" if we have never transmitted OR enough seconds have passed
+    // since the last one (i.e. we are in a new window, not the same one).
+    bool boundary_not_transmitted = (measStat.last_transmission_epoch == 0) || enough_time_passed;
+
+    // Measurement count guard: don't fire early (e.g. first boot at minute 0 reads
+    // only 1 sample before the boundary check would trigger).
+    bool enough_measurements = (measStat.measurement_count >= measStat.avg_measurements);
+
     int curr_hour = timeinfo.tm_hour;
-    bool boundary_not_transmitted = (measStat.last_transmission_hour != curr_hour) || (measStat.last_transmission_minute != measStat.curr_minutes);
-
-    // Enhanced logging for boundary logic debugging
-    int minutes_since_last_tx = 0;
-    if (measStat.last_transmission_minute >= 0)
-    {
-      if (measStat.curr_minutes > measStat.last_transmission_minute)
-      {
-        minutes_since_last_tx = measStat.curr_minutes - measStat.last_transmission_minute;
-      }
-      else if (measStat.curr_minutes < measStat.last_transmission_minute)
-      {
-        minutes_since_last_tx = (60 - measStat.last_transmission_minute) + measStat.curr_minutes;
-      }
-      else
-      {
-        // Same minute as last transmission - never allow retransmission
-        minutes_since_last_tx = 0;
-      }
-    }
-
-    log_i("TRANSMISSION CHECK: collected %d/%d measurements, boundary=%s (time %02d:%02d, interval=%d), last_tx=%02d:%02d",
+    log_i("TRANSMISSION CHECK: collected %d/%d measurements, boundary=%s (time %02d:%02d, interval=%d), last_tx_epoch=%lld, secs_since_tx=%d",
           measStat.measurement_count, measStat.avg_measurements,
           at_transmission_boundary ? "YES" : "NO", curr_hour, measStat.curr_minutes, measStat.max_measurements,
-          measStat.last_transmission_hour, measStat.last_transmission_minute);
+          (long long)measStat.last_transmission_epoch, seconds_since_last_tx);
 
-    log_i("BOUNDARY DETAILS: standard_boundary=%s, enough_time_passed=%s, minutes_since_last_tx=%d",
+    log_i("BOUNDARY DETAILS: standard_boundary=%s, enough_time_passed=%s, enough_measurements=%s",
           ((measStat.curr_minutes % measStat.max_measurements) == 0) ? "YES" : "NO",
-          enough_time_passed ? "YES" : "NO", minutes_since_last_tx);
+          enough_time_passed ? "YES" : "NO",
+          enough_measurements ? "YES" : "NO");
 
-    if (at_transmission_boundary && boundary_not_transmitted)
+    if (at_transmission_boundary && boundary_not_transmitted && enough_measurements)
     {
       log_i("All measurements obtained, going to send data...\n");
       mainStateMachine.next_state = SYS_STATE_SEND_DATA; // go to send data state
@@ -1491,9 +1463,9 @@ void loop()
     {
       log_i("Data enqueued successfully for network transmission");
       measStat.data_transmitted = true;                                // Mark data as transmitted for this cycle
-      measStat.last_transmission_minute = measStat.curr_minutes;       // Record the transmission boundary minute
-      measStat.last_transmission_hour = sendData.sendTimeInfo.tm_hour; // Record the transmission hour
-      log_i("Recorded transmission at %02d:%02d to prevent duplicates", measStat.last_transmission_hour, measStat.last_transmission_minute);
+      measStat.last_transmission_epoch = mktime(&sendData.sendTimeInfo); // Record epoch time to prevent duplicates
+      log_i("Recorded transmission epoch %lld (%02d:%02d) to prevent duplicates",
+            (long long)measStat.last_transmission_epoch, sendData.sendTimeInfo.tm_hour, sendData.sendTimeInfo.tm_min);
     }
     else
     {
@@ -1518,7 +1490,7 @@ void loop()
     log_i("TRANSMISSION ATTEMPT COMPLETE: Resetting measurement_count from %d to 0", measStat.measurement_count);
     measStat.measurement_count = 0;
     measStat.data_transmitted = false; // Reset flag for new measurement cycle
-    // Note: last_transmission_minute is NOT reset here - it stays to prevent duplicates at the same boundary
+    // Note: last_transmission_epoch is NOT reset here - it stays to prevent duplicates in the same boundary window
 
     // Reset all sensor data (both single and accumulated) for clean start of next cycle
     log_i("Resetting all sensor data for next measurement cycle");
@@ -1659,8 +1631,7 @@ void vMspInit_MeasInfo(void)
   measStat.avg_measurements = 1;
   measStat.isPmsAwake = false;
   measStat.isSensorDataAvailable = false;
-  measStat.last_transmission_minute = -1; // Initialize to invalid minute
-  measStat.last_transmission_hour = -1;   // Initialize to invalid hour
+  measStat.last_transmission_epoch = 0; // 0 = never transmitted
 }
 
 /**

--- a/msp-firmware.ino
+++ b/msp-firmware.ino
@@ -1472,8 +1472,8 @@ void loop()
       log_e("Failed to enqueue data for transmission - queue might be full");
     }
 
-    // show the already captured data
-    vMsp_updateDataAndSendEvent(DISP_EVENT_SHOW_MEAS_DATA, &sensorData_single, &devinfo, &measStat, &sysData, &sysStat);
+    // show the averaged data after transmission
+    vMsp_updateDataAndSendEvent(DISP_EVENT_SHOW_MEAS_DATA, &sensorData_accumulate, &devinfo, &measStat, &sysData, &sysStat);
 
     log_i("Data transmission time: %02d:%02d:%02d", sendData.sendTimeInfo.tm_hour, sendData.sendTimeInfo.tm_min, sendData.sendTimeInfo.tm_sec);
     log_i("temp: %.2f, hum: %.2f, pre: %.2f, VOC: %.2f, PM1: %d, PM25: %d, PM10: %d, MICS_CO: %.2f, MICS_NO2: %.2f, MICS_NH3: %.2f, ozone: %.2f, MSP: %d, measurement_count: %d vs %d",

--- a/msp-firmware.ino
+++ b/msp-firmware.ino
@@ -1478,7 +1478,7 @@ void loop()
     log_i("Writing data to SD card (mandatory logging)... SD status: %s", sysStat.sdCard ? "OK" : "FAIL");
     if (sysStat.sdCard)
     {
-      vHalSdcard_logToSD(&sendData, &sysData, &sysStat, &sensorData_single, &devinfo);
+      vHalSdcard_logToSD(&sendData, &sysData, &sysStat, &sensorData_accumulate, &devinfo);
       log_i("Data logged to SD card successfully with date-based folder structure");
     }
     else
@@ -1755,11 +1755,15 @@ void vMspInit_configureSystemFromSD(systemData_t *sysData, systemStatus_t *sysSt
       sysData->ntp_server = NTP_SERVER_DEFAULT;
       log_i("Applied default NTP server: %s", sysData->ntp_server.c_str());
     }
+    #ifdef FORCE_TIMEZONE_GMT0
+    sysData->timezone = TZ_DEFAULT;
+    #else
     if (sysData->timezone.length() == 0)
     {
       sysData->timezone = TZ_DEFAULT;
       log_i("Applied default timezone: %s", sysData->timezone.c_str());
     }
+    #endif
   }
   else
   {

--- a/network.cpp
+++ b/network.cpp
@@ -828,7 +828,11 @@ static bool syncDateTime(deviceNetworkInfo_t *devInfo, systemStatus_t *sysStatus
     updateDisplayStatus(devInfo, sysStatus, DISP_EVENT_RETRIEVE_DATETIME);
 
     // Get timezone rule (will be used by configTzTime later)
+    #ifndef FORCE_TIMEZONE_GMT0
     String tzRule = (sysData->timezone.length() > 0) ? sysData->timezone : TZ_DEFAULT;
+    #else
+    String tzRule = TZ_DEFAULT;
+    #endif
     log_i("Using timezone: %s", tzRule.c_str());
 
     // Validate NTP server

--- a/shared_values.h
+++ b/shared_values.h
@@ -259,8 +259,7 @@ typedef struct __MEASUREMENT__
   int32_t max_measurements;
   int32_t measurement_count; /*!< Number of measurements in the current cycle */
   bool data_transmitted; /*!< Flag to prevent duplicate transmissions in the same cycle */
-  int32_t last_transmission_minute; /*!< Last minute when data was transmitted to prevent duplicates */
-  int32_t last_transmission_hour; /*!< Last hour when data was transmitted to prevent duplicates (for hourly intervals) */
+  time_t last_transmission_epoch; /*!< Unix timestamp of last transmission (0 = never transmitted) */
   int32_t curr_minutes;
   int32_t curr_seconds;
   int32_t curr_total_seconds;


### PR DESCRIPTION
## Summary

This PR merges the `bugfix-4.1.5` branch into `main` in preparation for the **v4.1.6** release.

### SD Card CSV Logging
- Fixed CO/NOx/NH3 and `recordedAt` fields missing from CSV since commit `3e87c48`. `vHalSdcard_logToSD` was checking only `MICS6814Sensor` flag (ignoring `MICS4514Sensor`) and suppressing the ISO timestamp when `sysStat.datetime` was momentarily false during NTP re-sync.

### OLED Display
- Fixed CO/NOx/NH3 always showing `--`: `vHalDisplay_drawMICSxx14PollutionSensorData` only checked `MICS6814Sensor`, ignoring `MICS4514Sensor`.
- Fixed intermittent `--` on all sensor screens: `vMsp_updateDataAndSendEvent` only copied `sensorData` into the queue item for `DISP_EVENT_SHOW_MEAS_DATA`. All other events left `sensorData` zero-initialised; the display task's 1-second idle fallback then entered `DISP_EVENT_SHOW_MEAS_DATA` with all status flags false.
- Fixed post-transmission display showing the last individual reading instead of averaged values: `DISP_EVENT_SHOW_MEAS_DATA` after transmission now passes `&sensorData_accumulate`.

### Transmission Timing (60-minute interval)
- Fixed double transmission at minute `:00`: replaced `last_transmission_minute`/`last_transmission_hour` pair with a single `time_t last_transmission_epoch`. The old minute-based fallback could never fire for hourly intervals because `curr_minutes == last_transmission_minute` across the hour boundary forced `minutes_since_last_tx = 0`.
- Fixed premature first-cycle transmission on boot at minute `:00`: added `enough_measurements` guard (`measurement_count >= avg_measurements`).
- Fixed missed boundary window with no recovery: the seconds-based fallback fires even if evaluation runs late due to slow sensor reads.

### Build System
- Fixed `make env` failing with *"Unable to open file for logging"* when `var/log/` did not exist.

### Other
- Added force GMT0 timezone compile directive.
- Added `config_generator` tool.
- Removed `secure-release` workflow.

## Test plan

- [ ] Verify SD card CSV contains `recordedAt`, `nox`, `co`, `nh3` fields on a device with MICS4514
- [ ] Verify OLED shows CO/NOx/NH3 values (not `--`) during measurement cycle
- [ ] Verify no intermittent `--` on OLED after non-measurement events
- [ ] Verify 60-minute interval produces exactly one transmission per hour
- [ ] Verify `make env` succeeds on a clean checkout
- [ ] After merge: tag `v4.1.6` on `main` and push to trigger release workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)